### PR TITLE
- Adding enrage to normal / special buff tracking and '.auraType' to the auraIconFrame

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -4104,7 +4104,7 @@ end
 			auraIconFrame.layoutIndex = auraIconFrame.ID
 			auraIconFrame.IsShowingBuff = false
 			auraIconFrame.CanStealOrPurge = false
-			auraIconFrame.auraType = actualAuraType
+			auraIconFrame.AuraType = actualAuraType
 
 			if (auraType == "DEBUFF") then
 				auraIconFrame.filter = "HARMFUL"

--- a/Plater.lua
+++ b/Plater.lua
@@ -3635,6 +3635,8 @@ function Plater.OnInit() --private
 							scriptEnv._CanInterrupt = self.CanInterrupt
 							scriptEnv._EndTime = self.SpellEndTime
 							scriptEnv._RemainingTime = max (self.SpellEndTime - GetTime(), 0)
+							scriptEnv._CanStealOrPurge = self.CanStealOrPurge
+							scriptEnv._AuraType = self.AuraType
 							
 							--run
 							unitFrame:ScriptRunHook (scriptInfo, "Cast Start", self)
@@ -3702,6 +3704,8 @@ function Plater.OnInit() --private
 						scriptEnv._CanInterrupt = self.CanInterrupt
 						scriptEnv._EndTime = self.SpellEndTime
 						scriptEnv._RemainingTime = max (self.SpellEndTime - GetTime(), 0)
+						scriptEnv._CanStealOrPurge = self.CanStealOrPurge
+						scriptEnv._AuraType = self.AuraType
 						
 						if (self.casting) then
 							scriptEnv._CastPercent = self.value / self.maxValue * 100
@@ -3734,6 +3738,8 @@ function Plater.OnInit() --private
 							scriptEnv._CanInterrupt = self.CanInterrupt
 							scriptEnv._EndTime = self.SpellEndTime
 							scriptEnv._RemainingTime = max (self.SpellEndTime - GetTime(), 0)
+							scriptEnv._CanStealOrPurge = self.CanStealOrPurge
+							scriptEnv._AuraType = self.AuraType
 							
 							--run
 							unitFrame:ScriptRunHook (scriptInfo, "Cast Update", self)
@@ -4121,7 +4127,7 @@ end
 			auraIconFrame.layoutIndex = auraIconFrame.ID
 			auraIconFrame.IsShowingBuff = false
 			auraIconFrame.CanStealOrPurge = false
-			auraIconFrame.AuraType = actualAuraType
+			auraIconFrame.AuraType = AURA_TYPES[actualAuraType] or "NONE"
 
 			if (auraType == "DEBUFF") then
 				auraIconFrame.filter = "HARMFUL"
@@ -4297,6 +4303,8 @@ end
 			scriptEnv._StartTime = expirationTime - duration
 			scriptEnv._EndTime = expirationTime
 			scriptEnv._RemainingTime = max (expirationTime - GetTime(), 0)
+			scriptEnv._CanStealOrPurge = canStealOrPurge
+			scriptEnv._AuraType = AURA_TYPES[actualAuraType] or "NONE"
 			
 			--run onupdate script
 			auraIconFrame:ScriptRunOnUpdate (scriptInfo)

--- a/Plater.lua
+++ b/Plater.lua
@@ -318,11 +318,11 @@ local AURA_TYPE_UNKNOWN = nil
 
 --> As accessible translator map (where nil needs to resemble "NONE") for modding/scripting to be published in .AuraType:
 local AURA_TYPES = {
-	[""] = "ENRAGE",
-	["Macig"] = "MAGIC",
-	["Poison"] = "POISON",
-	["Curse"] = "CURSE",
-	["nil"] = "NONE",
+	[""] = "enrage",
+	["Magic"] = "magic",
+	["Poison"] = "poison",
+	["Curse"] = "curse",
+	["nil"] = "none",
 }
 
 --> icon texcoords
@@ -4127,7 +4127,7 @@ end
 			auraIconFrame.layoutIndex = auraIconFrame.ID
 			auraIconFrame.IsShowingBuff = false
 			auraIconFrame.CanStealOrPurge = false
-			auraIconFrame.AuraType = AURA_TYPES[actualAuraType] or "NONE"
+			auraIconFrame.AuraType = AURA_TYPES[actualAuraType] or "none"
 
 			if (auraType == "DEBUFF") then
 				auraIconFrame.filter = "HARMFUL"
@@ -4304,7 +4304,7 @@ end
 			scriptEnv._EndTime = expirationTime
 			scriptEnv._RemainingTime = max (expirationTime - GetTime(), 0)
 			scriptEnv._CanStealOrPurge = canStealOrPurge
-			scriptEnv._AuraType = AURA_TYPES[actualAuraType] or "NONE"
+			scriptEnv._AuraType = AURA_TYPES[actualAuraType] or "none"
 			
 			--run onupdate script
 			auraIconFrame:ScriptRunOnUpdate (scriptInfo)

--- a/Plater.lua
+++ b/Plater.lua
@@ -308,6 +308,23 @@ local ACTORTYPE_ENEMY_PLAYER = "enemyplayer"
 local ACTORTYPE_ENEMY_NPC = "enemynpc"
 local ACTORTYPE_PLAYER = "player"
 
+--> Aura types for usage in AddAura / AddExtraIcon checks
+local AURA_TYPE_ENRAGE = "" -- yes, 'enrage' is just empty string for Blizzard...
+local AURA_TYPE_MAGIC = "Magic"
+local AURA_TYPE_DISEASE = "Disease"
+local AURA_TYPE_POISON = "Poison"
+local AURA_TYPE_CURSE = "Curse"
+local AURA_TYPE_UNKNOWN = nil
+
+--> As accessible translator map (where nil needs to resemble "NONE") for modding/scripting to be published in .AuraType:
+local AURA_TYPES = {
+	[""] = "ENRAGE",
+	["Macig"] = "MAGIC",
+	["Poison"] = "POISON",
+	["Curse"] = "CURSE",
+	["nil"] = "NONE",
+}
+
 --> icon texcoords
 Plater.WideIconCoords = {.1, .9, .1, .6} --used in extra icons frame, constant,  can be changed with scripts
 Plater.BorderLessIconCoords = {.1, .9, .1, .9} --used in extra icons frame,constant, can be changed with scripts
@@ -4220,7 +4237,8 @@ end
 			--> for debuffs on the player for the personal bar
 			auraIconFrame:SetBackdropBorderColor (1, 0, 0, 1)
 		
-		elseif (actualAuraType == "") then -- enrage
+		elseif (actualAuraType == AURA_TYPE_ENRAGE) then 
+			--> enrage effects
 			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.enrage))
 			
 		else	
@@ -4351,7 +4369,8 @@ end
 		elseif (CROWDCONTROL_AURA_NAMES [spellName]) then
 			borderColor = Plater.db.profile.debuff_show_cc_border
 		
-		elseif (debuffType == "") then -- enrage effect
+		elseif (debuffType == AURA_TYPE_ENRAGE) then 
+			--> enrage effects
 			borderColor = Plater.db.profile.extra_icon_show_enrage_border
 		
 		else
@@ -4437,8 +4456,9 @@ end
 					--> check if is a special aura
 					if (not noSpecial) then
 						--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
-						--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+						--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge.
+						--> in addition, we want to check if enrage tracking is enabled and show enrage effects
+						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == AURA_TYPE_ENRAGE)) then
 							Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 						
 						--> check for special auras added by the user it self
@@ -4471,7 +4491,8 @@ end
 					if (not noSpecial) then
 						--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 						--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+						--> in addition, we want to check if enrage tracking is enabled and show enrage effects
+						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == AURA_TYPE_ENRAGE)) then
 							Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 						
 						--> check for special auras added by the user it self
@@ -4538,7 +4559,8 @@ end
 					
 					--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 					--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+					--> in addition, we want to check if enrage tracking is enabled and show enrage effects
+					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == AURA_TYPE_ENRAGE)) then
 						Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 						can_show_this_debuff = false
 					end
@@ -4582,7 +4604,8 @@ end
 					--> this special aura check is inside the 'buff banned' prevented because they are automatic added
 					--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 					--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+					--> in addition, we want to check if enrage tracking is enabled and show enrage effects
+					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == AURA_TYPE_ENRAGE)) then
 						Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 					else
 						--> important aura
@@ -4596,7 +4619,7 @@ end
 							Plater.AddAura (buffFrame, auraIconFrame, i, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId, nil, nil, nil, nil, actualAuraType)
 						
 						--> is enrage
-						elseif (DB_AURA_SHOW_ENRAGE and actualAuraType == "") then
+						elseif (DB_AURA_SHOW_ENRAGE and actualAuraType == AURA_TYPE_ENRAGE) then
 							local auraIconFrame, buffFrame = Plater.GetAuraIcon (self, true)
 							Plater.AddAura (buffFrame, auraIconFrame, i, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId, nil, nil, nil, nil, actualAuraType)
 						
@@ -4643,7 +4666,8 @@ end
 					
 					--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 					--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+					--> in addition, we want to check if enrage tracking is enabled and show enrage effects
+					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == AURA_TYPE_ENRAGE)) then
 						Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 					end
 				end

--- a/Plater.lua
+++ b/Plater.lua
@@ -643,6 +643,7 @@ Plater.DefaultSpellRangeList = {
 
 	local DB_AURA_SHOW_IMPORTANT
 	local DB_AURA_SHOW_DISPELLABLE
+	local DB_AURA_SHOW_ENRAGE
 	local DB_AURA_SHOW_BYPLAYER
 	local DB_AURA_SHOW_BYUNIT
 
@@ -686,6 +687,7 @@ Plater.DefaultSpellRangeList = {
 	local DB_CAPTURED_SPELLS = {}
 
 	local DB_SHOW_PURGE_IN_EXTRA_ICONS
+	local DB_SHOW_ENRAGE_IN_EXTRA_ICONS
 
 	--store the aggro color table for tanks and dps
 	local DB_AGGRO_TANK_COLORS
@@ -1281,6 +1283,7 @@ Plater.DefaultSpellRangeList = {
 
 		DB_AURA_SHOW_IMPORTANT = profile.aura_show_important
 		DB_AURA_SHOW_DISPELLABLE = profile.aura_show_dispellable
+		DB_AURA_SHOW_ENRAGE = profile.aura_show_enrage
 		DB_AURA_SHOW_BYPLAYER = profile.aura_show_aura_by_the_player
 		DB_AURA_SHOW_BYUNIT = profile.aura_show_buff_by_the_unit
 
@@ -1322,6 +1325,7 @@ Plater.DefaultSpellRangeList = {
 		DB_CAPTURED_SPELLS = profile.captured_spells
 		
 		DB_SHOW_PURGE_IN_EXTRA_ICONS = profile.extra_icon_show_purge
+		DB_SHOW_ENRAGE_IN_EXTRA_ICONS = profile.extra_icon_show_enrage
 		
 		Plater.MaxAurasPerRow = floor (profile.plate_config.enemynpc.health_incombat[1] / (profile.aura_width + Plater.AurasHorizontalPadding))
 		
@@ -4217,7 +4221,7 @@ end
 			auraIconFrame:SetBackdropBorderColor (1, 0, 0, 1)
 		
 		elseif (actualAuraType == "") then -- enrage
-			auraIconFrame:SetBackdropBorderColor (0.85, 0.2, 0.1, 1)
+			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.enrage))
 			
 		else	
 			auraIconFrame:SetBackdropBorderColor (0, 0, 0, 0)
@@ -4347,6 +4351,9 @@ end
 		elseif (CROWDCONTROL_AURA_NAMES [spellName]) then
 			borderColor = Plater.db.profile.debuff_show_cc_border
 		
+		elseif (debuffType == "") then -- enrage effect
+			borderColor = Plater.db.profile.extra_icon_show_enrage_border
+		
 		else
 			borderColor = Plater.db.profile.extra_icon_border_color
 		end
@@ -4431,12 +4438,12 @@ end
 					if (not noSpecial) then
 						--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 						--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge)) then
-							Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+							Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 						
 						--> check for special auras added by the user it self
 						elseif ((SPECIAL_AURAS_USER_LIST [name] and not SPECIAL_AURAS_USER_LIST_MINE [name]) or (SPECIAL_AURAS_USER_LIST_MINE [name] and caster and (UnitIsUnit (caster, "player") or UnitIsUnit (caster, "pet")))) then
-							Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+							Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 							
 						end
 					end
@@ -4464,12 +4471,12 @@ end
 					if (not noSpecial) then
 						--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 						--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge)) then
-							Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+						if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+							Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 						
 						--> check for special auras added by the user it self
 						elseif ((SPECIAL_AURAS_USER_LIST [name] and not SPECIAL_AURAS_USER_LIST_MINE [name]) or (SPECIAL_AURAS_USER_LIST_MINE [name] and caster and (UnitIsUnit (caster, "player") or UnitIsUnit (caster, "pet")))) then
-							Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+							Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 							
 						end
 					end
@@ -4531,15 +4538,15 @@ end
 					
 					--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 					--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge)) then
-						Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+						Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 						can_show_this_debuff = false
 					end
 				end
 				
 				--> check for special auras added by the user it self
 				if ((SPECIAL_AURAS_USER_LIST [name] and not SPECIAL_AURAS_USER_LIST_MINE [name]) or (SPECIAL_AURAS_USER_LIST_MINE [name] and caster and (UnitIsUnit (caster, "player") or UnitIsUnit (caster, "pet")))) then
-					Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+					Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 					can_show_this_debuff = false
 				end
 				
@@ -4561,7 +4568,7 @@ end
 				
 				--> check for special auras added by the user it self
 				if ((SPECIAL_AURAS_USER_LIST [name] and not SPECIAL_AURAS_USER_LIST_MINE [name]) or (SPECIAL_AURAS_USER_LIST_MINE [name] and caster and (UnitIsUnit (caster, "player") or UnitIsUnit (caster, "pet")))) then
-					Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+					Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 					
 				elseif (not DB_BUFF_BANNED [name]) then
 					--> if true it'll show all auras - this can be called from scripts to debug aura things
@@ -4575,8 +4582,8 @@ end
 					--> this special aura check is inside the 'buff banned' prevented because they are automatic added
 					--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 					--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge)) then
-						Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+						Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 					else
 						--> important aura
 						if (DB_AURA_SHOW_IMPORTANT and (nameplateShowAll or isBossDebuff)) then
@@ -4585,6 +4592,11 @@ end
 						
 						--> is dispellable or can be steal
 						elseif (DB_AURA_SHOW_DISPELLABLE and canStealOrPurge) then
+							local auraIconFrame, buffFrame = Plater.GetAuraIcon (self, true)
+							Plater.AddAura (buffFrame, auraIconFrame, i, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId, nil, nil, nil, nil, actualAuraType)
+						
+						--> is enrage
+						elseif (DB_AURA_SHOW_ENRAGE and actualAuraType == "") then
 							local auraIconFrame, buffFrame = Plater.GetAuraIcon (self, true)
 							Plater.AddAura (buffFrame, auraIconFrame, i, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId, nil, nil, nil, nil, actualAuraType)
 						
@@ -4631,14 +4643,14 @@ end
 					
 					--> check for special auras auto added by setting like 'show crowd control' or 'show dispellable'
 					--> SPECIAL_AURAS_AUTO_ADDED has a list of crowd control not do not have a list of dispellable, so check if canStealOrPurge
-					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge)) then
-						Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+					if (SPECIAL_AURAS_AUTO_ADDED [name] or (DB_SHOW_PURGE_IN_EXTRA_ICONS and canStealOrPurge) or (DB_SHOW_ENRAGE_IN_EXTRA_ICONS and actualAuraType == "")) then
+						Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 					end
 				end
 				
 				--> check for special auras added by the user it self
 				if ((SPECIAL_AURAS_USER_LIST [name] and not SPECIAL_AURAS_USER_LIST_MINE [name]) or (SPECIAL_AURAS_USER_LIST_MINE [name] and caster and (UnitIsUnit (caster, "player") or UnitIsUnit (caster, "pet")))) then
-					Plater.AddExtraIcon (self, name, texture, count, auraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
+					Plater.AddExtraIcon (self, name, texture, count, actualAuraType, duration, expirationTime, caster, canStealOrPurge, nameplateShowPersonal, spellId)
 				end
 				
 			end

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -632,6 +632,8 @@ PLATER_DEFAULT_SETTINGS = {
 		debuff_show_cc_border = {.3, .2, .2, 1},
 		extra_icon_show_purge = false, --extra frame show purge
 		extra_icon_show_purge_border = {0, .925, 1, 1},
+		extra_icon_show_enrage = false, --extra frame show purge
+		extra_icon_show_enrage_border = {0.85, 0.2, 0.1, 1},
 		
 		extra_icon_auras = {}, --auras for buff special tab
 		extra_icon_auras_mine = {}, --auras in the buff special that are only cast by the player
@@ -643,11 +645,13 @@ PLATER_DEFAULT_SETTINGS = {
 		
 		aura_show_important = true,
 		aura_show_dispellable = true,
+		aura_show_enrage = false,
 		aura_show_aura_by_the_player = true,
 		aura_show_buff_by_the_unit = true,
 		
 		aura_border_colors = {
 			steal_or_purge = {0, .5, .98, 1},
+			enrage = {0.85, 0.2, 0.1, 1},
 			is_buff = {0, .65, .1, 1},
 			is_show_all = {.7, .1, .1, 1},
 		},

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -1571,6 +1571,14 @@ auraOptionsFrame.AuraTesting = {
 			Duration = 5,
 			SpellID = 15407,
 		},
+		{
+			SpellName = "Enrage",
+			SpellTexture = 132345,
+			Count = 1,
+			Duration = 0,
+			SpellID = 228318,
+			Type = "",
+		},
 	},
 	
 	BUFF = {

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -1485,6 +1485,34 @@ local debuff_options = {
 	},
 	
 	{type = "blank"},
+	
+	{
+		type = "toggle",
+		get = function() return Plater.db.profile.aura_show_enrage end,
+		set = function (self, fixedparam, value) 
+			Plater.db.profile.aura_show_enrage = value
+			Plater.RefreshDBUpvalues()
+			Plater.UpdateAllPlates()
+		end,
+		name = "Show Enrage Buffs",
+		desc = "Show auras which are in the enrage category.",
+	},
+	{
+		type = "color",
+		get = function()
+			local color = Plater.db.profile.aura_border_colors.enrage
+			return {color[1], color[2], color[3], color[4]}
+		end,
+		set = function (self, r, g, b, a) 
+			local color = Plater.db.profile.aura_border_colors.enrage
+			color[1], color[2], color[3], color[4] = r, g, b, a
+			Plater.UpdateAllPlates()
+		end,
+		name = "Enrage Buffs Border Color",
+		desc = "Enrage Buffs Border Color",
+	},
+	
+	{type = "blank"},
 
 	{
 		type = "toggle",
@@ -3587,6 +3615,36 @@ Plater.CreateAuraTesting()
 				end,
 				name = "Dispellable Border Color",
 				desc = "Dispellable Border Color",
+			},
+			
+			{type = "blank"},
+			
+			--show enrages
+			{
+				type = "toggle",
+				get = function() return Plater.db.profile.extra_icon_show_enrage end,
+				set = function (self, fixedparam, value) 
+					Plater.db.profile.extra_icon_show_enrage = value
+					Plater.RefreshDBUpvalues()
+					Plater.UpdateAllPlates()
+				end,
+				name = "Enrage",
+				desc = "When the unit has an enrage effect on it, show it.",
+			},
+			--purge border color
+			{
+				type = "color",
+				get = function()
+					local color = Plater.db.profile.extra_icon_show_enrage_border
+					return {color[1], color[2], color[3], color[4]}
+				end,
+				set = function (self, r, g, b, a) 
+					local color = Plater.db.profile.extra_icon_show_enrage_border
+					color[1], color[2], color[3], color[4] = r, g, b, a
+					Plater.UpdateAllPlates()
+				end,
+				name = "Enrage Border Color",
+				desc = "Enrage Border Color",
 			},
 		
 		}


### PR DESCRIPTION
Adding the auraType to the auraIconFrame to start supporting rage effect tracking. Can be used to track any other aura type as well:
Disease", "Poison", "Curse", "Magic", "" (yes, empty string. this is how Blizzard rolls apparently) for enrage and nil/"none" for uncategorized.