### PR TITLE
- Additional options for friendly players name colors

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -5741,21 +5741,21 @@ end
 			PixelUtil.SetPoint (plateFrame.ActorNameSpecial, "center", plateFrame, "center", 0, 10)
 			
 			--format the color if is the same guild, a friend from friends list or color by player class
-			if (Plater.db.profile.use_guild_color and plateFrame.playerGuildName == Plater.PlayerGuildName) then
+			if (Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_guild_color and plateFrame.playerGuildName == Plater.PlayerGuildName) then
 				--is a guild friend?
-				DF:SetFontColor (nameFontString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color))
+				DF:SetFontColor (nameFontString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_guild_color))
 				plateFrame.isFriend = true
 				
-			elseif (Plater.db.profile.use_friends_color and Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
+			elseif (Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_friends_color and Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
 				--is regular friend
-				DF:SetFontColor (nameFontString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color))
+				DF:SetFontColor (nameFontString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_friend_color))
 				--DF:SetFontOutline (nameFontString, plateConfigs.actorname_text_shadow)
 				Plater.SetFontOutlineAndShadow (nameFontString, plateConfigs.actorname_text_outline, plateConfigs.actorname_text_shadow_color, plateConfigs.actorname_text_shadow_color_offset[1], plateConfigs.actorname_text_shadow_color_offset[2])
 				plateFrame.isFriend = true
 				
 			else
 				--isn't friend, check if is showing only the name and if is showing class colors
-				if (Plater.db.profile.use_playerclass_color) then
+				if (Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_class_color) then
 					local _, unitClass = UnitClass (plateFrame [MEMBER_UNITID])
 					if (unitClass) then
 						local color = RAID_CLASS_COLORS [unitClass]
@@ -5933,20 +5933,35 @@ end
 			end
 		end
 		
-		if (Plater.db.profile.use_guild_color and plateFrame.playerGuildName == Plater.PlayerGuildName) then
+		if (Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_guild_color and plateFrame.playerGuildName == Plater.PlayerGuildName) then
 			--is a guild friend?
-			DF:SetFontColor (nameString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color))
-			DF:SetFontColor (guildString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color))
+			DF:SetFontColor (nameString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_guild_color))
+			DF:SetFontColor (guildString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_guild_color))
 			plateFrame.isFriend = true
 		
-		elseif (Plater.db.profile.use_friends_color and Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
+		elseif (Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_friends_color and Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
 			--is regular friend
-			DF:SetFontColor (nameString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color))
-			DF:SetFontColor (guildString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color))
+			DF:SetFontColor (nameString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_friend_color))
+			DF:SetFontColor (guildString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_friend_color))
 			plateFrame.isFriend = true		
 
+		elseif (Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_class_color) then
+			--class colors should be used, if possible, because this is enabled
+			plateFrame.isFriend = nil
+			
+			local _, unitClass = UnitClass (plateFrame [MEMBER_UNITID])
+			if (unitClass) then
+				local color = RAID_CLASS_COLORS [unitClass]
+				DF:SetFontColor (nameString, color.r, color.g, color.b)
+				DF:SetFontColor (guildString, color.r, color.g, color.b)
+			else
+				DF:SetFontColor (nameString, plateConfigs.actorname_text_color)
+				DF:SetFontColor (guildString, plateConfigs.actorname_text_color)
+			end
+		
 		else
 			DF:SetFontColor (nameString, plateConfigs.actorname_text_color)
+			DF:SetFontColor (guildString, plateConfigs.actorname_text_color)
 			plateFrame.isFriend = nil
 		end
 

--- a/Plater.lua
+++ b/Plater.lua
@@ -5741,14 +5741,14 @@ end
 			PixelUtil.SetPoint (plateFrame.ActorNameSpecial, "center", plateFrame, "center", 0, 10)
 			
 			--format the color if is the same guild, a friend from friends list or color by player class
-			if (plateFrame.playerGuildName == Plater.PlayerGuildName) then
+			if (Plater.db.profile.use_guild_color and plateFrame.playerGuildName == Plater.PlayerGuildName) then
 				--is a guild friend?
-				DF:SetFontColor (nameFontString, "PLATER_GUILD")
+				DF:SetFontColor (nameFontString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color))
 				plateFrame.isFriend = true
 				
-			elseif (Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
+			elseif (Plater.db.profile.use_friends_color and Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
 				--is regular friend
-				DF:SetFontColor (nameFontString, "PLATER_FRIEND")
+				DF:SetFontColor (nameFontString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color))
 				--DF:SetFontOutline (nameFontString, plateConfigs.actorname_text_shadow)
 				Plater.SetFontOutlineAndShadow (nameFontString, plateConfigs.actorname_text_outline, plateConfigs.actorname_text_shadow_color, plateConfigs.actorname_text_shadow_color_offset[1], plateConfigs.actorname_text_shadow_color_offset[2])
 				plateFrame.isFriend = true
@@ -5933,16 +5933,16 @@ end
 			end
 		end
 		
-		if (plateFrame.playerGuildName == Plater.PlayerGuildName) then
+		if (Plater.db.profile.use_guild_color and plateFrame.playerGuildName == Plater.PlayerGuildName) then
 			--is a guild friend?
-			DF:SetFontColor (nameString, "PLATER_GUILD")
-			DF:SetFontColor (guildString, "PLATER_GUILD")
+			DF:SetFontColor (nameString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color))
+			DF:SetFontColor (guildString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color))
 			plateFrame.isFriend = true
 		
-		elseif (Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
+		elseif (Plater.db.profile.use_friends_color and Plater.FriendsCache [plateFrame [MEMBER_NAME]]) then
 			--is regular friend
-			DF:SetFontColor (nameString, "PLATER_FRIEND")
-			DF:SetFontColor (guildString, "PLATER_FRIEND")
+			DF:SetFontColor (nameString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color))
+			DF:SetFontColor (guildString, unpack(Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color))
 			plateFrame.isFriend = true		
 
 		else

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -94,8 +94,6 @@ PLATER_DEFAULT_SETTINGS = {
 				show_guild_name = false,
 				
 				fixed_class_color = {0, 1, 0},
-				friend_color = {.71, 1, 1, 1},
-				guild_color = {0.498039, 1, .2, 1},
 				
 				health = {70, 2},
 				health_incombat = {70, 2},
@@ -109,7 +107,12 @@ PLATER_DEFAULT_SETTINGS = {
 				actorname_text_spacing = 10,
 				actorname_text_size = 10,
 				actorname_text_font = "Arial Narrow",
+				actorname_use_class_color = false,
 				actorname_text_color = {1, 1, 1, 1},
+				actorname_friend_color = {.71, 1, 1, 1},
+				actorname_use_friends_color = true,
+				actorname_guild_color = {0.498039, 1, .2, 1},
+				actorname_use_guild_color = true,
 				actorname_text_outline = "OUTLINE",
 				actorname_text_shadow_color = {0, 0, 0, 1},
 				actorname_text_shadow_color_offset = {1, -1},
@@ -560,8 +563,6 @@ PLATER_DEFAULT_SETTINGS = {
 		update_throttle = 0.25,
 		culling_distance = 100,
 		use_playerclass_color = true, --friendly player
-		use_friends_color = true, -- on your friend list coloring
-		use_guild_color = true, -- in your guild coloring
 		
 		use_health_animation = false,
 		health_animation_time_dilatation = 2.615321,

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -41,6 +41,7 @@ DF:InstallTemplate ("font", "PLATER_BUTTON_DISABLED", {color = {1/3, .8/3, .2/3}
 --button templates
 DF:InstallTemplate ("button", "PLATER_BUTTON_DISABLED", {backdropcolor = {.4, .4, .4, .3}, backdropbordercolor = {0, 0, 0, .5}}, "OPTIONS_BUTTON_TEMPLATE")
 
+-- those two may be removed, as they are covered by settings now
 DF:NewColor ("PLATER_FRIEND", .71, 1, 1, 1)
 DF:NewColor ("PLATER_GUILD", 0.498039, 1, .2, 1)
 
@@ -93,6 +94,8 @@ PLATER_DEFAULT_SETTINGS = {
 				show_guild_name = false,
 				
 				fixed_class_color = {0, 1, 0},
+				friend_color = {.71, 1, 1, 1},
+				guild_color = {0.498039, 1, .2, 1},
 				
 				health = {70, 2},
 				health_incombat = {70, 2},
@@ -557,6 +560,8 @@ PLATER_DEFAULT_SETTINGS = {
 		update_throttle = 0.25,
 		culling_distance = 100,
 		use_playerclass_color = true, --friendly player
+		use_friends_color = true, -- on your friend list coloring
+		use_guild_color = true, -- in your guild coloring
 		
 		use_health_animation = false,
 		health_animation_time_dilatation = 2.615321,

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -6103,54 +6103,6 @@ local relevance_options = {
 		},
 		{
 			type = "toggle",
-			get = function() return Plater.db.profile.use_friends_color end,
-			set = function (self, fixedparam, value) 
-				Plater.db.profile.use_friends_color = value
-				Plater.UpdateAllPlates()
-			end,
-			name = "Use Friends Colors",
-			desc = "Player name/guild text uses the selected friend color, if the player is on your friend list.\n(Overwriting class colors)",
-		},
-		{
-			type = "color",
-			get = function()
-				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color
-				return {color[1], color[2], color[3], color[4]}
-			end,
-			set = function (self, r, g, b, a) 
-				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color
-				color[1], color[2], color[3], color[4] = r, g, b, a
-				Plater.UpdateAllPlates()
-			end,
-			name = "Friend Color",
-			desc = "Use this color for name/guild texts if the player is your friend.",
-		},
-		{
-			type = "toggle",
-			get = function() return Plater.db.profile.use_guild_color end,
-			set = function (self, fixedparam, value) 
-				Plater.db.profile.use_guild_color = value
-				Plater.UpdateAllPlates()
-			end,
-			name = "Use Guild Colors",
-			desc = "Player name/guild text uses the selected guild color, if it is a guild mate.\n(Overwriting class colors)",
-		},
-		{
-			type = "color",
-			get = function()
-				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color
-				return {color[1], color[2], color[3], color[4]}
-			end,
-			set = function (self, r, g, b, a) 
-				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color
-				color[1], color[2], color[3], color[4] = r, g, b, a
-				Plater.UpdateAllPlates()
-			end,
-			name = "Guild Color",
-			desc = "Use this color for name/guild texts if the player is in your guild.",
-		},
-		{
-			type = "toggle",
 			get = function() return Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].only_damaged end,
 			set = function (self, fixedparam, value) 
 				Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].only_damaged = value
@@ -6206,6 +6158,82 @@ local relevance_options = {
 			usedecimals = true,
 			name = L["OPTIONS_YOFFSET"],
 			desc = "Adjust the position on the Y axis.\n\n|cFFFFFF00Important|r: right click to type the value.",
+		},
+		
+		{type = "blank"},
+		{type = "label", get = function() return "Player Name Text Colors" end, text_template = DF:GetTemplate ("font", "ORANGE_FONT_TEMPLATE")},
+		--player name color
+		{
+			type = "toggle",
+			get = function() return Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_class_color end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_class_color = value
+				Plater.UpdateAllPlates()
+			end,
+			name = "Use Class Colors",
+			desc = "Player name/guild text uses the class color instead of the selected color. Guild or Friend colors will overwrite this, if used.",
+		},
+		{
+			type = "toggle",
+			get = function() return Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_friends_color end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_friends_color = value
+				Plater.UpdateAllPlates()
+			end,
+			name = "Use Friends Colors",
+			desc = "Player name/guild text uses the selected friend color, if the player is on your friend list.",
+		},
+		{
+			type = "toggle",
+			get = function() return Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_guild_color end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_use_guild_color = value
+				Plater.UpdateAllPlates()
+			end,
+			name = "Use Guild Colors",
+			desc = "Player name/guild text uses the selected guild color, if it is a guild mate.",
+		},
+		{
+			type = "color",
+			get = function()
+				local color = Plater.db.profile.plate_config.friendlyplayer.actorname_text_color
+				return {color[1], color[2], color[3], color[4]}
+			end,
+			set = function (self, r, g, b, a) 
+				local color = Plater.db.profile.plate_config.friendlyplayer.actorname_text_color
+				color[1], color[2], color[3], color[4] = r, g, b, a
+				Plater.UpdateAllPlates()
+			end,
+			name = L["OPTIONS_COLOR"],
+			desc = "The color of the text, if neither class, friend or guild colors are used.",
+		},
+		{
+			type = "color",
+			get = function()
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_friend_color
+				return {color[1], color[2], color[3], color[4]}
+			end,
+			set = function (self, r, g, b, a) 
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_friend_color
+				color[1], color[2], color[3], color[4] = r, g, b, a
+				Plater.UpdateAllPlates()
+			end,
+			name = "Friend Color",
+			desc = "Use this color for name/guild texts if the player is your friend.",
+		},
+		{
+			type = "color",
+			get = function()
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_guild_color
+				return {color[1], color[2], color[3], color[4]}
+			end,
+			set = function (self, r, g, b, a) 
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].actorname_guild_color
+				color[1], color[2], color[3], color[4] = r, g, b, a
+				Plater.UpdateAllPlates()
+			end,
+			name = "Guild Color",
+			desc = "Use this color for name/guild texts if the player is in your guild.",
 		},
 		
 		{type = "breakline"},
@@ -6351,21 +6379,6 @@ local relevance_options = {
 			values = function() return DF:BuildDropDownFontList (on_select_friendly_playername_font) end,
 			name = L["OPTIONS_FONT"],
 			desc = "Font of the text.",
-		},
-		--player name color
-		{
-			type = "color",
-			get = function()
-				local color = Plater.db.profile.plate_config.friendlyplayer.actorname_text_color
-				return {color[1], color[2], color[3], color[4]}
-			end,
-			set = function (self, r, g, b, a) 
-				local color = Plater.db.profile.plate_config.friendlyplayer.actorname_text_color
-				color[1], color[2], color[3], color[4] = r, g, b, a
-				Plater.UpdateAllPlates()
-			end,
-			name = L["OPTIONS_COLOR"],
-			desc = "The color of the text.",
 		},
 		
 		--text outline options

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -6099,7 +6099,55 @@ local relevance_options = {
 				Plater.UpdateAllPlates()
 			end,
 			name = "Fixed Color",
-			desc = "Use this color when not using class colors.",
+			desc = "Use this color for health-bars and guild/friend text when not using class colors.\nGuild and friend colors for the name/guild texts can be overwritten with their respective color settings below.",
+		},
+		{
+			type = "toggle",
+			get = function() return Plater.db.profile.use_friends_color end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.use_friends_color = value
+				Plater.UpdateAllPlates()
+			end,
+			name = "Use Friends Colors",
+			desc = "Player name/guild text uses the selected friend color, if the player is on your friend list.\n(Overwriting class colors)",
+		},
+		{
+			type = "color",
+			get = function()
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color
+				return {color[1], color[2], color[3], color[4]}
+			end,
+			set = function (self, r, g, b, a) 
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].friend_color
+				color[1], color[2], color[3], color[4] = r, g, b, a
+				Plater.UpdateAllPlates()
+			end,
+			name = "Friend Color",
+			desc = "Use this color for name/guild texts if the player is your friend.",
+		},
+		{
+			type = "toggle",
+			get = function() return Plater.db.profile.use_guild_color end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.use_guild_color = value
+				Plater.UpdateAllPlates()
+			end,
+			name = "Use Guild Colors",
+			desc = "Player name/guild text uses the selected guild color, if it is a guild mate.\n(Overwriting class colors)",
+		},
+		{
+			type = "color",
+			get = function()
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color
+				return {color[1], color[2], color[3], color[4]}
+			end,
+			set = function (self, r, g, b, a) 
+				local color = Plater.db.profile.plate_config [ACTORTYPE_FRIENDLY_PLAYER].guild_color
+				color[1], color[2], color[3], color[4] = r, g, b, a
+				Plater.UpdateAllPlates()
+			end,
+			name = "Guild Color",
+			desc = "Use this color for name/guild texts if the player is in your guild.",
 		},
 		{
 			type = "toggle",


### PR DESCRIPTION
Adding options to chose and enable/disable the friend, guild and class color for the name/guild texts.
Moving the text color options to a separate block, away from the other name text options, to not disturb the menu.

This still might need some cleanup, but it is working and ready for a review. :)