### PR TITLE
-fix nameplate size after interface-options menu closes

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -3885,7 +3885,8 @@ function Plater.OnInit() --private
 		end
 	end)
 	
-	
+	-- hook to the InterfaceOptionsFrame and update the nameplate sizes, as blizzard somehow messes things up there on hide...
+	InterfaceOptionsFrame:HookScript('OnHide',Plater.UpdatePlateClickSpace)
 end
 
 


### PR DESCRIPTION
Somehow Blizzard resets the nameplate size after the interface options are closed. Hooking into OnHide of InterfaceOptionsFrame to call UpdatePlateClickSpace.