### PR TITLE
- change behavior of friendly players "only name" or "only damaged" options

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -6943,7 +6943,7 @@ end
 	function Plater.ParseHealthSettingForPlayer (plateFrame) --private
 		plateFrame.IsFriendlyPlayerWithoutHealthBar = false
 
-		if (DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].only_thename) then
+		if (DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].only_thename and not DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].only_damaged) then
 			Plater.HideHealthBar (plateFrame.unitFrame)
 			plateFrame.IsFriendlyPlayerWithoutHealthBar = true
 			

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -6119,7 +6119,7 @@ local relevance_options = {
 				Plater.UpdateAllPlates()
 			end,
 			name = "Only Show Player Name",
-			desc = "Hide the health bar, only show the character name.\n\n|cFFFFFF00Important|r: overrides 'Only Damaged Players'.",
+			desc = "Hide the health bar, only show the character name.\n\n|cFFFFFF00Important|r: If 'Only Damaged Players' is selected and the player is damaged, this setting will be overwritten and the health bar will be shown.",
 		},
 		{
 			type = "toggle",


### PR DESCRIPTION
With this change, the "Only Show Player Name" option will no longer fully overwrite the "Only Damaged Players" option for friendly nameplates.
In case both are selected either name or bar will be shown, depending on the health of the player.

Current behavior:
![image](https://user-images.githubusercontent.com/10164755/57106862-c1de3800-6d2e-11e9-9bbf-459845b584a3.png)

New bevavior:
![image](https://user-images.githubusercontent.com/10164755/57106876-cacf0980-6d2e-11e9-9e50-1657722f268d.png)

