### PR TITLE
- fixing friendly player name/healthbar switch for only damaged + only name options

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -5360,7 +5360,7 @@ end
 			if (unitFrame.ScheduleNameUpdate) then
 				if (unitFrame.ActorType == ACTORTYPE_FRIENDLY_PLAYER) then
 					tickFrame.PlateFrame.playerGuildName = GetGuildInfo (tickFrame.unit)
-					Plater.UpdatePlateText (tickFrame.PlateFrame, DB_PLATE_CONFIG [unitFrame.ActorType], false)
+					Plater.UpdatePlateText (tickFrame.PlateFrame, DB_PLATE_CONFIG [unitFrame.ActorType], true)
 				end
 				
 				Plater.UpdateUnitName (tickFrame.PlateFrame)
@@ -7156,7 +7156,7 @@ end
 			if (UnitHealth (plateFrame [MEMBER_UNITID]) < UnitHealthMax (plateFrame [MEMBER_UNITID])) then
 				Plater.ShowHealthBar (plateFrame.unitFrame)
 			else
-				Plater.HideHealthBar (plateFrame.unitFrame)
+				Plater.HideHealthBar (plateFrame.unitFrame, true)
 				
 				if (DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].only_thename) then
 					plateFrame.IsFriendlyPlayerWithoutHealthBar = true


### PR DESCRIPTION
When both "only the name" and "only damaged" for friendly players are selected, the nameplate did not update properly when the target was healed to full health or damaged.
This fix forces a proper update when switching between both states.