### PR TITLE
- fixing friendly player name/healthbar switch for only damaged + only name options (part 2)

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -8639,6 +8639,7 @@ end
 		unitFrame.healthBar:Show()
 		unitFrame.BuffFrame:Show()
 		unitFrame.BuffFrame2:Show()
+		unitFrame.ExtraIconFrame:Show()
 		unitFrame.healthBar.unitName:Show()
 		
 		unitFrame.PlateFrame.IsFriendlyPlayerWithoutHealthBar = false
@@ -8654,6 +8655,7 @@ end
 		unitFrame.healthBar:Hide()
 		unitFrame.BuffFrame:Hide()
 		unitFrame.BuffFrame2:Hide()
+		unitFrame.ExtraIconFrame:Hide()
 		unitFrame.healthBar.unitName:Hide()
 		
 		unitFrame.PlateFrame.IsFriendlyPlayerWithoutHealthBar = showPlayerName

--- a/Plater.lua
+++ b/Plater.lua
@@ -5364,7 +5364,7 @@ end
 			if (unitFrame.ScheduleNameUpdate) then
 				if (unitFrame.ActorType == ACTORTYPE_FRIENDLY_PLAYER) then
 					tickFrame.PlateFrame.playerGuildName = GetGuildInfo (tickFrame.unit)
-					Plater.UpdatePlateText (tickFrame.PlateFrame, DB_PLATE_CONFIG [unitFrame.ActorType], true)
+					Plater.UpdatePlateText (tickFrame.PlateFrame, DB_PLATE_CONFIG [unitFrame.ActorType], false)
 				end
 				
 				Plater.UpdateUnitName (tickFrame.PlateFrame)
@@ -7153,7 +7153,7 @@ end
 		plateFrame.IsFriendlyPlayerWithoutHealthBar = false
 
 		if (DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].only_thename and not DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].only_damaged) then
-			Plater.HideHealthBar (plateFrame.unitFrame)
+			Plater.HideHealthBar (plateFrame.unitFrame, true)
 			plateFrame.IsFriendlyPlayerWithoutHealthBar = true
 			
 		elseif (DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER].only_damaged) then
@@ -8645,6 +8645,8 @@ end
 		
 		unitFrame.ActorNameSpecial:Hide()
 		unitFrame.ActorTitleSpecial:Hide()
+		
+		Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [unitFrame.ActorType], false)
 	end
 
 	--hide the health bar and show the secondary unit name and title text strings

--- a/Plater.lua
+++ b/Plater.lua
@@ -8646,7 +8646,7 @@ end
 		unitFrame.ActorNameSpecial:Hide()
 		unitFrame.ActorTitleSpecial:Hide()
 		
-		Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [unitFrame.ActorType], false)
+		Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [unitFrame.ActorType], true)
 	end
 
 	--hide the health bar and show the secondary unit name and title text strings
@@ -8660,10 +8660,10 @@ end
 		unitFrame.PlateFrame.IsNpcWithoutHealthBar = showNameNpc
 		
 		if (showPlayerName) then
-			Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER], false)
+			Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [ACTORTYPE_FRIENDLY_PLAYER], true)
 			
 		elseif (showNameNpc) then
-			Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [ACTORTYPE_ENEMY_NPC], false)
+			Plater.UpdatePlateText (unitFrame.PlateFrame, DB_PLATE_CONFIG [ACTORTYPE_ENEMY_NPC], true)
 		end
 	end
 	


### PR DESCRIPTION
Part 2: When both "only the name" and "only damaged" for friendly players are selected, the nameplate did not update properly when the target was healed to full health or damaged.
This fix forces a proper update when switching between both states.