### PR TITLE
Debuff type color update

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -4368,13 +4368,15 @@ end
 			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.steal_or_purge))
 			auraIconFrame.CanStealOrPurge = true
 		
+		elseif (Plater.db.profile.aura_border_colors_by_type) then
+			-- use Blizzards color global 'DebuffTypeColor' for the actual color:
+			local color = DebuffTypeColor[actualAuraType or "none"] or {r=0,b=0,g=0, a=0}
+			auraIconFrame:SetBackdropBorderColor (color.r, color.g, color.b, color.a or 1)
+		
 		elseif (isBuff) then
 			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.is_buff))
 			auraIconFrame.IsShowingBuff = true
 		
-		elseif (isShowAll) then
-			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.is_show_all))
-			
 		elseif (isDebuff) then
 			--> for debuffs on the player for the personal bar
 			auraIconFrame:SetBackdropBorderColor (1, 0, 0, 1)
@@ -4382,11 +4384,13 @@ end
 		elseif (actualAuraType == AURA_TYPE_ENRAGE) then 
 			--> enrage effects
 			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.enrage))
+		
+		elseif (isShowAll) then
+			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.is_show_all))
+				
+		else
+			auraIconFrame:SetBackdropBorderColor (0, 0, 0, 0)
 			
-		else	
-			-- use Blizzards color global 'DebuffTypeColor' for the actual color:
-			local color = DebuffTypeColor[actualAuraType or "none"] or {r=0,b=0,g=0, a=0}
-			auraIconFrame:SetBackdropBorderColor (color.r, color.g, color.b, color.a or 1)
 		end
 		
 		CooldownFrame_Set (auraIconFrame.Cooldown, expirationTime - duration, duration, duration > 0, true)
@@ -4511,7 +4515,7 @@ end
 		if (canStealOrPurge) then
 			borderColor = Plater.db.profile.extra_icon_show_purge_border
 			
-		elseif (Plater.db.profile.extra_icon_use_blizzard_border_color)
+		elseif (Plater.db.profile.extra_icon_use_blizzard_border_color) then
 			-- use blizzard border colors
 			local color = DebuffTypeColor[actualAuraType or "none"] or {r=0,b=0,g=0, a=0}
 			borderColor = {color.r, color.g, color.b, color.a or 1}

--- a/Plater.lua
+++ b/Plater.lua
@@ -4384,9 +4384,9 @@ end
 			auraIconFrame:SetBackdropBorderColor (unpack (profile.aura_border_colors.enrage))
 			
 		else	
-			auraIconFrame:SetBackdropBorderColor (0, 0, 0, 0)
-			-- could use Blizzards color global 'DebuffTypeColor' for the actual color, e.g.:
-			-- auraIconFrame:SetBackdropBorderColor (unpack(DebuffTypeColor[actualAuraType or "none"]))
+			-- use Blizzards color global 'DebuffTypeColor' for the actual color:
+			local color = DebuffTypeColor[actualAuraType or "none"] or {r=0,b=0,g=0, a=0}
+			auraIconFrame:SetBackdropBorderColor (color.r, color.g, color.b, color.a or 1)
 		end
 		
 		CooldownFrame_Set (auraIconFrame.Cooldown, expirationTime - duration, duration, duration > 0, true)
@@ -4511,6 +4511,11 @@ end
 		if (canStealOrPurge) then
 			borderColor = Plater.db.profile.extra_icon_show_purge_border
 			
+		elseif (Plater.db.profile.extra_icon_use_blizzard_border_color)
+			-- use blizzard border colors
+			local color = DebuffTypeColor[actualAuraType or "none"] or {r=0,b=0,g=0, a=0}
+			borderColor = {color.r, color.g, color.b, color.a or 1}
+			
 		elseif (CROWDCONTROL_AURA_NAMES [spellName]) then
 			borderColor = Plater.db.profile.debuff_show_cc_border
 		
@@ -4520,6 +4525,7 @@ end
 		
 		else
 			borderColor = Plater.db.profile.extra_icon_border_color
+			
 		end
 		
 		--spellId, borderColor, startTime, duration, forceTexture, descText

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -657,6 +657,7 @@ PLATER_DEFAULT_SETTINGS = {
 		aura_show_enrage = false,
 		aura_show_aura_by_the_player = true,
 		aura_show_buff_by_the_unit = true,
+		aura_border_colors_by_type = false,
 		
 		aura_border_colors = {
 			steal_or_purge = {0, .5, .98, 1},

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -632,6 +632,7 @@ PLATER_DEFAULT_SETTINGS = {
 		extra_icon_width = 30,
 		extra_icon_height = 18,
 		extra_icon_wide_icon = true,
+		extra_icon_use_blizzard_border_color = true,
 		extra_icon_caster_name = true,
 		extra_icon_backdrop_color = {0, 0, 0, 0.612853},
 		extra_icon_border_color = {0, 0, 0, 1},

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -1582,6 +1582,20 @@ local debuff_options = {
 	},	
 	
 	{type = "blank"},
+
+	{
+		type = "toggle",
+		get = function() return Plater.db.profile.aura_border_colors_by_type end,
+		set = function (self, fixedparam, value) 
+			Plater.db.profile.aura_border_colors_by_type = value
+			Plater.RefreshDBUpvalues()
+			Plater.UpdateAllPlates()
+		end,
+		name = "Use type based aura border colors",
+		desc = "Use the Blizzard debuff type colors for borders",
+	},
+	
+	{type = "blank"},
 	{type = "label", get = function() return "Swipe Animation:" end, text_template = DF:GetTemplate ("font", "ORANGE_FONT_TEMPLATE")},
 	{
 		type = "select",

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -1624,6 +1624,7 @@ auraOptionsFrame.AuraTesting = {
 			Count = 1,
 			Duration = 7,
 			SpellID = 589,
+			Type = "Magic",
 		},
 		{
 			SpellName = "Vampiric Touch",
@@ -1631,6 +1632,7 @@ auraOptionsFrame.AuraTesting = {
 			Count = 1,
 			Duration = 5,
 			SpellID = 34914,
+			Type = "Magic",
 		},
 		{
 			SpellName = "Mind Flay",
@@ -1638,6 +1640,7 @@ auraOptionsFrame.AuraTesting = {
 			Count = 3,
 			Duration = 5,
 			SpellID = 15407,
+			Type = "Magic",
 		},
 		{
 			SpellName = "Enrage",
@@ -3577,6 +3580,17 @@ Plater.CreateAuraTesting()
 				end,
 				name = "Wide Icons",
 				desc = "Wide Icons",
+			},
+			--use blizzard border colors
+			{
+				type = "toggle",
+				get = function() return Plater.db.profile.extra_icon_use_blizzard_border_color end,
+				set = function (self, fixedparam, value) 
+					Plater.db.profile.extra_icon_use_blizzard_border_color = value
+					Plater.UpdateAllPlates()
+				end,
+				name = "Use Blizzard border colors",
+				desc = "Use Blizzard border colors if enabled or the below defined default border color if disabled.",
 			},
 			--border color
 			{


### PR DESCRIPTION
- adding usage of DebuffTypeColor for aura border colors
Default aura border will now be matched against DebuffTypeColor, a Blizzard global.
Options added to use this feature for Extra Icons as well.
- adding option to use blizzard type colors for buff borders