### PR TITLE
Adding LibCustomGlow support

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -67,6 +67,7 @@ local max = math.max
 local min = math.min
 
 local LibSharedMedia = LibStub:GetLibrary ("LibSharedMedia-3.0")
+local LCG = LibStub:GetLibrary("LibCustomGlow-1.0")
 local _
 
 local Plater = DF:CreateAddOn ("Plater", "PlaterDB", PLATER_DEFAULT_SETTINGS, { --options table
@@ -8582,6 +8583,181 @@ end
 			unitFrame = unitFrame.unitFrame
 		end
 		return unitFrame.castBar, unitFrame.castBar.Text
+	end
+	
+	--create a glow around the frame using LibCustomGlow - defaults to "button" glow
+	--[[ options can be used to create different glow types, see https://www.curseforge.com/wow/addons/libcustomglow
+		--type "pixel"
+		options = {
+			glowType = "pixel",
+			color = "white", -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
+			N = 8, -- number of lines. Defaul value is 8;
+			frequency = 0.25, -- frequency, set to negative to inverse direction of rotation. Default value is 0.25;
+			length = 4, -- length of lines. Default value depends on region size and number of lines;
+			th = 2, -- thickness of lines. Default value is 2;
+			xOffset = 0,
+			yOffset = 0, -- offset of glow relative to region border;
+			border = false, -- set to true to create border under lines;
+			key = "", -- key of glow, allows for multiple glows on one frame;
+		}
+		
+		-- type "ants"
+		options = {
+			glowType = "ants",
+			color = "white", -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
+			N = 4, -- number of particle groups. Each group contains 4 particles. Defaul value is 4;
+			frequency = 0.125, -- frequency, set to negative to inverse direction of rotation. Default value is 0.125;
+			scale = 1, -- scale of particles
+			xOffset = 0,
+			yOffset = 0, -- offset of glow relative to region border;
+			key = "", -- key of glow, allows for multiple glows on one frame;
+		}
+		
+		-- type "button"
+		options = {
+			glowType = "button",
+			color = "white", -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
+			frequency = 0.125, -- frequency, set to negative to inverse direction of rotation. Default value is 0.125;
+		}
+	--]]
+	function Plater.StartGlow(frame, color, options, key)
+		if not frame then return end
+		
+		if not color and (options and options.color) then
+			color = options.color
+		end
+		if color then
+			local r, g, b, a = DF:ParseColors (color)
+			color = {r, g, b, a}
+			options.color = color
+		end
+		
+		if not options then
+			options = {
+				glowType = "button",
+				color = color,
+				key = key or "",
+			}
+		end
+		
+		if not options.glowType then
+			options.glowType = "button"
+		end
+		
+		if key then
+			options.key = key
+		end
+		
+		if (not frame.__PlaterGlowFrame) then
+			frame.__PlaterGlowFrame = CreateFrame("Frame", nil, frame);
+			frame.__PlaterGlowFrame:SetAllPoints(frame);
+			frame.__PlaterGlowFrame:SetSize(frame:GetSize());
+		end
+		
+		if options.glowType == "button" then
+			LCG.ButtonGlow_Start(frame.__PlaterGlowFrame, options.color, options.frequency)
+		elseif options.glowType == "pixel" then
+			if not options.border then options.border = false end
+			LCG.PixelGlow_Start(frame.__PlaterGlowFrame, options.color, options.N, options.frequency, options.length, options.th, options.xOffset, options.yOffset, options.border, options.key or "")
+		elseif options.glowType == "ants" then
+			LCG.AutoCastGlow_Start(frame.__PlaterGlowFrame, options.color, options.N, options.frequency, options.scale, options.xOffset, options.yOffset, options.key or "")
+		end
+	end
+	
+	-- creates a button glow effect
+	function Plater.StartButtonGlow(frame, color, options)
+		-- type "button"
+		if not options then
+			options = {
+				glowType = "button",
+				color = color, -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
+				frequency = 0.125, -- frequency, set to negative to inverse direction of rotation. Default value is 0.125;
+			}
+		else
+			options.glowType = "button"
+		end
+		
+		Plater.StartGlow(frame, color, options)
+	end
+	
+	-- creates an ants glow effect
+	function Plater.StartAntsGlow(frame, color, options, key)
+		-- type "ants"
+		if not options then
+			options = {
+				glowType = "ants",
+				color = color,
+				N = 4, -- number of particle groups. Each group contains 4 particles. Defaul value is 4;
+				frequency = 0.125, -- frequency, set to negative to inverse direction of rotation. Default value is 0.125;
+				scale = 1, -- scale of particles
+				xOffset = 0,
+				yOffset = 0, -- offset of glow relative to region border;
+				key = key or "", -- key of glow, allows for multiple glows on one frame;
+			}
+		else
+			options.glowType = "ants"
+		end
+		
+		Plater.StartGlow(frame, color, options, key)
+	end
+	
+	-- creates a pixel glow effect
+	function Plater.StartPixelGlow(frame, color, options, key)
+		-- type "pixel"
+		if not options then
+			options = {
+				glowType = "pixel",
+				color = color, -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
+				N = 8, -- number of lines. Defaul value is 8;
+				frequency = 0.25, -- frequency, set to negative to inverse direction of rotation. Default value is 0.25;
+				--length = 4, -- length of lines. Default value depends on region size and number of lines;
+				th = 2, -- thickness of lines. Default value is 2;
+				xOffset = 0,
+				yOffset = 0, -- offset of glow relative to region border;
+				border = false, -- set to true to create border under lines;
+				key = key or "", -- key of glow, allows for multiple glows on one frame;
+			}
+		else
+			options.glowType = "pixel"
+		end
+		
+		Plater.StartGlow(frame, color, options, key)
+	end
+	
+	-- stop LibCustomGlow effects on the frame, if existing
+	-- if glowType (and key) are given, stop one glow. if not, stop all.
+	function Plater.StopGlow(frame, glowType, key)
+		if not frame then return end
+		if not frame.__PlaterGlowFrame then return end
+		
+		if glowType then		
+			if glowType == "button" then
+				LCG.ButtonGlow_Stop(frame.__PlaterGlowFrame, key or "")
+			elseif glowType == "pixel" then
+				LCG.PixelGlow_Stop(frame.__PlaterGlowFrame, key or "")
+			elseif glowType == "ants" then
+				LCG.AutoCastGlow_Stop(frame.__PlaterGlowFrame, key or "")
+			end
+		else
+			LCG.ButtonGlow_Stop(frame.__PlaterGlowFrame, key or "")
+			LCG.PixelGlow_Stop(frame.__PlaterGlowFrame, key or "")
+			LCG.AutoCastGlow_Stop(frame.__PlaterGlowFrame, key or "")
+		end
+	end
+	
+	-- stop a button glow
+	function Plater.StopButtonGlow(frame, key)
+		Plater.StopGlow(frame, "button", key)
+	end
+	
+	-- stop a button glow
+	function Plater.StopPixelGlow(frame, key)
+		Plater.StopGlow(frame, "pixel", key)
+	end
+	
+	-- stop an ants glow
+	function Plater.StopAntsGlow(frame, key)
+		Plater.StopGlow(frame, "ants", key)
 	end
 
 	--create a glow around an icon

--- a/libs/LibCustomGlow-1.0/CHANGES.txt
+++ b/libs/LibCustomGlow-1.0/CHANGES.txt
@@ -1,0 +1,16 @@
+tag b1ff2a53194668ff943328a9c6e9b1ac2ca488e8 1.0.1
+Author:	Benjamin Staneck <staneck@gmail.com>
+Date:	Fri Feb 1 21:43:59 2019 +0100
+
+commit 409960e5730f8490facec60cdee993e5b8af9b74
+Author: Benjamin Staneck <staneck@gmail.com>
+Date:   Fri Dec 14 04:05:29 2018 +0100
+
+    Update TOC for Patch 8.1
+
+commit 46a3d5879f9ac5e11d8d69e74d750d795bb8e7e4
+Author: deezo <dooezzz@gmail.com>
+Date:   Sun Jan 27 19:02:36 2019 +0300
+
+    Reapplying blizzard glow to the frame now updates glow size
+

--- a/libs/LibCustomGlow-1.0/LibCustomGlow-1.0.lua
+++ b/libs/LibCustomGlow-1.0/LibCustomGlow-1.0.lua
@@ -1,0 +1,690 @@
+local MAJOR_VERSION = "LibCustomGlow-1.0"
+local MINOR_VERSION = 14
+if not LibStub then error(MAJOR_VERSION .. " requires LibStub.") end
+local lib, oldversion = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
+if not lib then return end
+local Masque = LibStub("Masque", true)
+
+local textureList = {
+    ["empty"] = [[Interface\AdventureMap\BrokenIsles\AM_29]],
+    ["white"] = [[Interface\BUTTONS\WHITE8X8]],
+    ["shine"] = [[Interface\Artifacts\Artifacts]]
+}
+
+function lib.RegisterTextures(texture,id)
+    textureList[id] = texture
+end
+
+lib.glowList = {}
+lib.startList = {}
+lib.stopList = {}
+
+local GlowParent = UIParent
+
+local GlowMaskPool = CreateFromMixins(ObjectPoolMixin)
+lib.GlowMaskPool = GlowMaskPool
+local function MaskPoolFactory(maskPool)
+    return maskPool.parent:CreateMaskTexture()
+end
+
+local MaskPoolResetter = function(maskPool,mask)
+    mask:Hide()
+    mask:ClearAllPoints()
+end
+
+ObjectPoolMixin.OnLoad(GlowMaskPool,MaskPoolFactory,MaskPoolResetter)
+GlowMaskPool.parent =  GlowParent
+
+local TexPoolResetter = function(pool,tex)
+    local maskNum = tex:GetNumMaskTextures()
+    for i = maskNum,1 do
+        tex:RemoveMaskTexture(tex:GetMaskTexture(i))
+    end
+    tex:Hide()
+    tex:ClearAllPoints()
+end
+local GlowTexPool = CreateTexturePool(GlowParent ,"ARTWORK",7,nil,TexPoolResetter)
+lib.GlowTexPool = GlowTexPool
+
+local FramePoolResetter = function(framePool,frame)
+    frame:SetScript("OnUpdate",nil)
+    local parent = frame:GetParent()
+    if parent[frame.name] then
+        parent[frame.name] = nil
+    end
+    if frame.textures then
+        for _, texture in pairs(frame.textures) do
+            GlowTexPool:Release(texture)
+        end
+    end
+    if frame.bg then
+        GlowTexPool:Release(frame.bg)
+        frame.bg = nil
+    end
+    if frame.masks then
+        for _,mask in pairs(frame.masks) do
+            GlowMaskPool:Release(mask)
+        end
+        frame.masks = nil
+    end
+    frame.textures = {}
+    frame.info = {}
+    frame.name = nil
+    frame.timer = nil
+    frame:Hide()
+    frame:ClearAllPoints()
+end
+local GlowFramePool = CreateFramePool("Frame",GlowParent,nil,FramePoolResetter)
+lib.GlowFramePool = GlowFramePool
+
+local function addFrameAndTex(r,color,name,key,N,xOffset,yOffset,texture,texCoord,desaturated)
+    key = key or ""
+    if not r[name..key] then
+        r[name..key] = GlowFramePool:Acquire()
+        r[name..key]:SetParent(r)
+        r[name..key]:SetFrameLevel(r:GetFrameLevel()+8)
+        r[name..key].name = name..key
+    end
+    local f = r[name..key]
+    f:SetPoint("TOPLEFT",r,"TOPLEFT",-xOffset+0.05,yOffset+0.05)
+    f:SetPoint("BOTTOMRIGHT",r,"BOTTOMRIGHT",xOffset,-yOffset+0.05)
+    f:Show()
+
+    if not f.textures then
+        f.textures = {}
+    end
+
+    for i=1,N do
+        if not f.textures[i] then
+            f.textures[i] = GlowTexPool:Acquire()
+            f.textures[i]: SetTexture(texture)
+            f.textures[i]: SetTexCoord(texCoord[1],texCoord[2],texCoord[3],texCoord[4])
+            f.textures[i]: SetDesaturated(desaturated)
+            f.textures[i]: SetParent(f)
+            f.textures[i]: SetDrawLayer("ARTWORK",7)
+        end
+        f.textures[i]:SetVertexColor(color[1],color[2],color[3],color[4])
+        f.textures[i]:Show()
+    end
+    while #f.textures>N do
+        GlowTexPool:Release(f.textures[#f.textures])
+        table.remove(f.textures)
+    end
+end
+
+
+--Pixel Glow Functions--
+local pCalc1 = function(progress,s,th,p)
+    local c
+    if progress>p[3] or progress<p[0] then
+        c = 0
+    elseif progress>p[2] then
+        c =s-th-(progress-p[2])/(p[3]-p[2])*(s-th)
+    elseif progress>p[1] then
+        c =s-th
+    else
+        c = (progress-p[0])/(p[1]-p[0])*(s-th)
+    end
+    return math.floor(c+0.5)
+end
+
+local pCalc2 = function(progress,s,th,p)
+    local c
+    if progress>p[3] then
+        c = s-th-(progress-p[3])/(p[0]+1-p[3])*(s-th)
+    elseif progress>p[2] then
+        c = s-th
+    elseif progress>p[1] then
+        c = (progress-p[1])/(p[2]-p[1])*(s-th)
+    elseif progress>p[0] then
+        c = 0
+    else
+        c = s-th-(progress+1-p[3])/(p[0]+1-p[3])*(s-th)
+    end
+    return math.floor(c+0.5)
+end
+
+local  pUpdate = function(self,elapsed)
+    self.timer = self.timer+elapsed/self.info.period
+    if self.timer>1 or self.timer <-1 then
+        self.timer = self.timer%1
+    end
+    local progress = self.timer
+    local width,height = self:GetSize()
+    if width ~= self.info.width or height ~= self.info.height then
+        local perimeter = 2*(width+height)
+        if not (perimeter>0) then
+            return
+        end
+        self.info.width = width
+        self.info.height = height
+        self.info.pTLx = {
+            [0] = (height+self.info.length/2)/perimeter,
+            [1] = (height+width+self.info.length/2)/perimeter,
+            [2] = (2*height+width-self.info.length/2)/perimeter,
+            [3] = 1-self.info.length/2/perimeter
+        }
+        self.info.pTLy ={
+            [0] = (height-self.info.length/2)/perimeter,
+            [1] = (height+width+self.info.length/2)/perimeter,
+            [2] = (height*2+width+self.info.length/2)/perimeter,
+            [3] = 1-self.info.length/2/perimeter
+        }
+        self.info.pBRx ={
+            [0] = self.info.length/2/perimeter,
+            [1] = (height-self.info.length/2)/perimeter,
+            [2] = (height+width-self.info.length/2)/perimeter,
+            [3] = (height*2+width+self.info.length/2)/perimeter
+        }
+        self.info.pBRy ={
+            [0] = self.info.length/2/perimeter,
+            [1] = (height+self.info.length/2)/perimeter,
+            [2] = (height+width-self.info.length/2)/perimeter,
+            [3] = (height*2+width-self.info.length/2)/perimeter
+        }
+    end
+    if self:IsShown() then
+        if not (self.masks[1]:IsShown()) then
+            self.masks[1]:Show()
+            self.masks[1]:SetPoint("TOPLEFT",self,"TOPLEFT",self.info.th,-self.info.th)
+            self.masks[1]:SetPoint("BOTTOMRIGHT",self,"BOTTOMRIGHT",-self.info.th,self.info.th)
+        end
+        if self.masks[2] and not(self.masks[2]:IsShown()) then
+            self.masks[2]:Show()
+            self.masks[2]:SetPoint("TOPLEFT",self,"TOPLEFT",self.info.th+1,-self.info.th-1)
+            self.masks[2]:SetPoint("BOTTOMRIGHT",self,"BOTTOMRIGHT",-self.info.th-1,self.info.th+1)
+        end
+        if self.bg and not(self.bg:IsShown()) then
+            self.bg:Show()
+        end
+        for k,line  in pairs(self.textures) do
+            line:SetPoint("TOPLEFT",self,"TOPLEFT",pCalc1((progress+self.info.step*(k-1))%1,width,self.info.th,self.info.pTLx),-pCalc2((progress+self.info.step*(k-1))%1,height,self.info.th,self.info.pTLy))
+            line:SetPoint("BOTTOMRIGHT",self,"TOPLEFT",self.info.th+pCalc2((progress+self.info.step*(k-1))%1,width,self.info.th,self.info.pBRx),-height+pCalc1((progress+self.info.step*(k-1))%1,height,self.info.th,self.info.pBRy))
+        end
+    end
+end
+
+function lib.PixelGlow_Start(r,color,N,frequency,length,th,xOffset,yOffset,border,key)
+    if not r then
+        return
+    end
+    if not color then
+        color = {0.95,0.95,0.32,1}
+    end
+
+    if not(N and N>0) then
+        N = 8
+    end
+
+    local period
+    if frequency then
+        if not(frequency>0 or frequency<0) then
+            period = 4
+        else
+            period = 1/frequency
+        end
+    else
+        period = 4
+    end
+    local width,height = r:GetSize()
+    length = length or math.floor((width+height)*(2/N-0.1))
+    length = min(length,min(width,height))
+    th = th or 1
+    xOffset = xOffset or 0
+    yOffset = yOffset or 0
+    key = key or ""
+
+    addFrameAndTex(r,color,"_PixelGlow",key,N,xOffset,yOffset,textureList.white,{0,1,0,1},nil)
+    local f = r["_PixelGlow"..key]
+    if not f.masks then
+        f.masks = {}
+    end
+    if not f.masks[1] then
+        f.masks[1] = GlowMaskPool:Acquire()
+        f.masks[1]:SetTexture(textureList.empty, "CLAMPTOWHITE","CLAMPTOWHITE")
+        f.masks[1]:Show()
+    end
+    f.masks[1]:SetPoint("TOPLEFT",f,"TOPLEFT",th,-th)
+    f.masks[1]:SetPoint("BOTTOMRIGHT",f,"BOTTOMRIGHT",-th,th)
+
+    if not(border==false) then
+        if not f.masks[2] then
+            f.masks[2] = GlowMaskPool:Acquire()
+            f.masks[2]:SetTexture(textureList.empty, "CLAMPTOWHITE","CLAMPTOWHITE")
+        end
+        f.masks[2]:SetPoint("TOPLEFT",f,"TOPLEFT",th+1,-th-1)
+        f.masks[2]:SetPoint("BOTTOMRIGHT",f,"BOTTOMRIGHT",-th-1,th+1)
+
+        if not f.bg then
+            f.bg = GlowTexPool:Acquire()
+            f.bg:SetColorTexture(0.1,0.1,0.1,0.8)
+            f.bg:SetParent(f)
+            f.bg:SetAllPoints(f)
+            f.bg:SetDrawLayer("ARTWORK",6)
+            f.bg:AddMaskTexture(f.masks[2])
+        end
+    else
+        if f.bg then
+            GlowTexPool:Release(f.bg)
+            f.bg = nil
+        end
+        if f.masks[2] then
+            GlowMaskPool:Release(f.masks[2])
+            f.masks[2] = nil
+        end
+    end
+    for _,tex in pairs(f.textures) do
+        if tex:GetNumMaskTextures() < 1 then
+            tex:AddMaskTexture(f.masks[1])
+        end
+    end
+    f.timer = f.timer or 0
+    f.info = f.info or {}
+    f.info.step = 1/N
+    f.info.period = period
+    f.info.th = th
+    if f.info.length ~= length then
+        f.info.width = nil
+        f.info.length = length
+    end
+    f:SetScript("OnUpdate",pUpdate)
+end
+
+function lib.PixelGlow_Stop(r,key)
+    if not r then
+        return
+    end
+    key = key or ""
+    if not r["_PixelGlow"..key] then
+        return false
+    else
+        GlowFramePool:Release(r["_PixelGlow"..key])
+    end
+end
+
+table.insert(lib.glowList, "Pixel Glow")
+lib.startList["Pixel Glow"] = lib.PixelGlow_Start
+lib.stopList["Pixel Glow"] = lib.PixelGlow_Stop
+
+
+--Autocast Glow Funcitons--
+local function acUpdate(self,elapsed)
+    local width,height = self:GetSize()
+    if width ~= self.info.width or height ~= self.info.height then
+        self.info.width = width
+        self.info.height = height
+        self.info.perimeter = 2*(width+height)
+        self.info.bottomlim = height*2+width
+        self.info.rightlim = height+width
+        self.info.space = self.info.perimeter/self.info.N
+    end
+
+    local texIndex = 0;
+    for k=1,4 do
+        self.timer[k] = self.timer[k]+elapsed/(self.info.period*k)
+        if self.timer[k] > 1 or self.timer[k] <-1 then
+            self.timer[k] = self.timer[k]%1
+        end
+        for i = 1,self.info.N do
+            texIndex = texIndex+1
+            local position = (self.info.space*i+self.info.perimeter*self.timer[k])%self.info.perimeter
+            if position>self.info.bottomlim then
+                self.textures[texIndex]: SetPoint("CENTER",self,"BOTTOMRIGHT",-position+self.info.bottomlim,0)
+            elseif position>self.info.rightlim then
+                self.textures[texIndex]: SetPoint("CENTER",self,"TOPRIGHT",0,-position+self.info.rightlim)
+            elseif position>self.info.height then
+                self.textures[texIndex]: SetPoint("CENTER",self,"TOPLEFT",position-self.info.height,0)
+            else
+                self.textures[texIndex]: SetPoint("CENTER",self,"BOTTOMLEFT",0,position)
+            end
+        end
+    end
+end
+
+function lib.AutoCastGlow_Start(r,color,N,frequency,scale,xOffset,yOffset,key)
+    if not r then
+        return
+    end
+
+    if not color then
+        color = {0.95,0.95,0.32,1}
+    end
+
+    if not(N and N>0) then
+        N = 4
+    end
+
+    local period
+    if frequency then
+        if not(frequency>0 or frequency<0) then
+            period = 8
+        else
+            period = 1/frequency
+        end
+    else
+        period = 8
+    end
+    scale = scale or 1
+    xOffset = xOffset or 0
+    yOffset = yOffset or 0
+    key = key or ""
+
+    addFrameAndTex(r,color,"_AutoCastGlow",key,N*4,xOffset,yOffset,textureList.shine,{0.8115234375,0.9169921875,0.8798828125,0.9853515625},true)
+    local f = r["_AutoCastGlow"..key]
+    local sizes = {7,6,5,4}
+    for k,size in pairs(sizes) do
+        for i = 1,N do
+            f.textures[i+N*(k-1)]:SetSize(size*scale,size*scale)
+        end
+    end
+    f.timer = f.timer or {0,0,0,0}
+    f.info = f.info or {}
+    f.info.N = N
+    f.info.period = period
+    f:SetScript("OnUpdate",acUpdate)
+end
+
+function lib.AutoCastGlow_Stop(r,key)
+    if not r then
+        return
+    end
+
+    key = key or ""
+    if not r["_AutoCastGlow"..key] then
+        return false
+    else
+        GlowFramePool:Release(r["_AutoCastGlow"..key])
+    end
+end
+
+table.insert(lib.glowList, "Autocast Shine")
+lib.startList["Autocast Shine"] = lib.AutoCastGlow_Start
+lib.stopList["Autocast Shine"] = lib.AutoCastGlow_Stop
+
+--Action Button Glow--
+local function ButtonGlowResetter(framePool,frame)
+    frame:SetScript("OnUpdate",nil)
+    local parent = frame:GetParent()
+    if parent._ButtonGlow then
+        parent._ButtonGlow = nil
+    end
+    frame:Hide()
+    frame:ClearAllPoints()
+end
+local ButtonGlowPool = CreateFramePool("Frame",GlowParent,nil,ButtonGlowResetter)
+lib.ButtonGlowPool = ButtonGlowPool
+
+local function CreateScaleAnim(group, target, order, duration, x, y, delay)
+    local scale = group:CreateAnimation("Scale")
+    scale:SetChildKey(target)
+    scale:SetOrder(order)
+    scale:SetDuration(duration)
+    scale:SetScale(x, y)
+
+    if delay then
+        scale:SetStartDelay(delay)
+    end
+end
+
+local function CreateAlphaAnim(group, target, order, duration, fromAlpha, toAlpha, delay, appear)
+    local alpha = group:CreateAnimation("Alpha")
+    alpha:SetChildKey(target)
+    alpha:SetOrder(order)
+    alpha:SetDuration(duration)
+    alpha:SetFromAlpha(fromAlpha)
+    alpha:SetToAlpha(toAlpha)
+    if delay then
+        alpha:SetStartDelay(delay)
+    end
+    if appear then
+        table.insert(group.appear, alpha)
+    else
+        table.insert(group.fade, alpha)
+    end
+end
+
+local function AnimIn_OnPlay(group)
+    local frame = group:GetParent()
+    local frameWidth, frameHeight = frame:GetSize()
+    frame.spark:SetSize(frameWidth, frameHeight)
+    frame.spark:SetAlpha(not(frame.color) and 1.0 or 0.3*frame.color[4])
+    frame.innerGlow:SetSize(frameWidth / 2, frameHeight / 2)
+    frame.innerGlow:SetAlpha(not(frame.color) and 1.0 or frame.color[4])
+    frame.innerGlowOver:SetAlpha(not(frame.color) and 1.0 or frame.color[4])
+    frame.outerGlow:SetSize(frameWidth * 2, frameHeight * 2)
+    frame.outerGlow:SetAlpha(not(frame.color) and 1.0 or frame.color[4])
+    frame.outerGlowOver:SetAlpha(not(frame.color) and 1.0 or frame.color[4])
+    frame.ants:SetSize(frameWidth * 0.85, frameHeight * 0.85)
+    frame.ants:SetAlpha(0)
+    frame:Show()
+end
+
+local function AnimIn_OnFinished(group)
+    local frame = group:GetParent()
+    local frameWidth, frameHeight = frame:GetSize()
+    frame.spark:SetAlpha(0)
+    frame.innerGlow:SetAlpha(0)
+    frame.innerGlow:SetSize(frameWidth, frameHeight)
+    frame.innerGlowOver:SetAlpha(0.0)
+    frame.outerGlow:SetSize(frameWidth, frameHeight)
+    frame.outerGlowOver:SetAlpha(0.0)
+    frame.outerGlowOver:SetSize(frameWidth, frameHeight)
+    frame.ants:SetAlpha(not(frame.color) and 1.0 or frame.color[4])
+end
+
+local function AnimIn_OnStop(group)
+    local frame = group:GetParent()
+    local frameWidth, frameHeight = frame:GetSize()
+    frame.spark:SetAlpha(0)
+    frame.innerGlow:SetAlpha(0)
+    frame.innerGlowOver:SetAlpha(0.0)
+    frame.outerGlowOver:SetAlpha(0.0)
+end
+
+local function bgHide(self)
+    if self.animOut:IsPlaying() then
+        self.animOut:Stop()
+        ButtonGlowPool:Release(self)
+    end
+end
+
+local function bgUpdate(self, elapsed)
+    AnimateTexCoords(self.ants, 256, 256, 48, 48, 22, elapsed, self.throttle);
+    local cooldown = self:GetParent().cooldown;
+    if(cooldown and cooldown:IsShown() and cooldown:GetCooldownDuration() > 3000) then
+        self:SetAlpha(0.5);
+    else
+        self:SetAlpha(1.0);
+    end
+end
+
+local function configureButtonGlow(f,alpha)
+    f.spark = f:CreateTexture(nil, "BACKGROUND")
+    f.spark:SetPoint("CENTER")
+    f.spark:SetAlpha(0)
+    f.spark:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+    f.spark:SetTexCoord(0.00781250, 0.61718750, 0.00390625, 0.26953125)
+
+    -- inner glow
+    f.innerGlow = f:CreateTexture(nil, "ARTWORK")
+    f.innerGlow:SetPoint("CENTER")
+    f.innerGlow:SetAlpha(0)
+    f.innerGlow:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+    f.innerGlow:SetTexCoord(0.00781250, 0.50781250, 0.27734375, 0.52734375)
+
+    -- inner glow over
+    f.innerGlowOver = f:CreateTexture(nil, "ARTWORK")
+    f.innerGlowOver:SetPoint("TOPLEFT", f.innerGlow, "TOPLEFT")
+    f.innerGlowOver:SetPoint("BOTTOMRIGHT", f.innerGlow, "BOTTOMRIGHT")
+    f.innerGlowOver:SetAlpha(0)
+    f.innerGlowOver:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+    f.innerGlowOver:SetTexCoord(0.00781250, 0.50781250, 0.53515625, 0.78515625)
+
+    -- outer glow
+    f.outerGlow = f:CreateTexture(nil, "ARTWORK")
+    f.outerGlow:SetPoint("CENTER")
+    f.outerGlow:SetAlpha(0)
+    f.outerGlow:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+    f.outerGlow:SetTexCoord(0.00781250, 0.50781250, 0.27734375, 0.52734375)
+
+    -- outer glow over
+    f.outerGlowOver = f:CreateTexture(nil, "ARTWORK")
+    f.outerGlowOver:SetPoint("TOPLEFT", f.outerGlow, "TOPLEFT")
+    f.outerGlowOver:SetPoint("BOTTOMRIGHT", f.outerGlow, "BOTTOMRIGHT")
+    f.outerGlowOver:SetAlpha(0)
+    f.outerGlowOver:SetTexture([[Interface\SpellActivationOverlay\IconAlert]])
+    f.outerGlowOver:SetTexCoord(0.00781250, 0.50781250, 0.53515625, 0.78515625)
+
+    -- ants
+    f.ants = f:CreateTexture(nil, "OVERLAY")
+    f.ants:SetPoint("CENTER")
+    f.ants:SetAlpha(0)
+    f.ants:SetTexture([[Interface\SpellActivationOverlay\IconAlertAnts]])
+
+    f.animIn = f:CreateAnimationGroup()
+    f.animIn.appear = {}
+    f.animIn.fade = {}
+    CreateScaleAnim(f.animIn, "spark",          1, 0.2, 1.5, 1.5)
+    CreateAlphaAnim(f.animIn, "spark",          1, 0.2, 0, alpha, nil, true)
+    CreateScaleAnim(f.animIn, "innerGlow",      1, 0.3, 2, 2)
+    CreateScaleAnim(f.animIn, "innerGlowOver",  1, 0.3, 2, 2)
+    CreateAlphaAnim(f.animIn, "innerGlowOver",  1, 0.3, alpha, 0, nil, false)
+    CreateScaleAnim(f.animIn, "outerGlow",      1, 0.3, 0.5, 0.5)
+    CreateScaleAnim(f.animIn, "outerGlowOver",  1, 0.3, 0.5, 0.5)
+    CreateAlphaAnim(f.animIn, "outerGlowOver",  1, 0.3, alpha, 0, nil, false)
+    CreateScaleAnim(f.animIn, "spark",          1, 0.2, 2/3, 2/3, 0.2)
+    CreateAlphaAnim(f.animIn, "spark",          1, 0.2, alpha, 0, 0.2, false)
+    CreateAlphaAnim(f.animIn, "innerGlow",      1, 0.2, alpha, 0, 0.3, false)
+    CreateAlphaAnim(f.animIn, "ants",           1, 0.2, 0, alpha, 0.3, true)
+    f.animIn:SetScript("OnPlay", AnimIn_OnPlay)
+    f.animIn:SetScript("OnStop", AnimIn_OnStop)
+    f.animIn:SetScript("OnFinished", AnimIn_OnFinished)
+
+    f.animOut = f:CreateAnimationGroup()
+    f.animOut.appear = {}
+    f.animOut.fade = {}
+    CreateAlphaAnim(f.animOut, "outerGlowOver", 1, 0.2, 0, alpha, nil, true)
+    CreateAlphaAnim(f.animOut, "ants",          1, 0.2, alpha, 0, nil, false)
+    CreateAlphaAnim(f.animOut, "outerGlowOver", 2, 0.2, alpha, 0, nil, false)
+    CreateAlphaAnim(f.animOut, "outerGlow",     2, 0.2, alpha, 0, nil, false)
+    f.animOut:SetScript("OnFinished", function(self) ButtonGlowPool:Release(self:GetParent())  end)
+
+    f:SetScript("OnHide", bgHide)
+end
+
+local function updateAlphaAnim(f,alpha)
+    for _,anim in pairs(f.animIn.appear) do
+        anim:SetToAlpha(alpha)
+    end
+    for _,anim in pairs(f.animIn.fade) do
+        anim:SetFromAlpha(alpha)
+    end
+    for _,anim in pairs(f.animOut.appear) do
+        anim:SetToAlpha(alpha)
+    end
+    for _,anim in pairs(f.animOut.fade) do
+        anim:SetFromAlpha(alpha)
+    end
+end
+
+local ButtonGlowTextures = {["spark"] = true,["innerGlow"] = true,["innerGlowOver"] = true,["outerGlow"] = true,["outerGlowOver"] = true,["ants"] = true}
+
+function lib.ButtonGlow_Start(r,color,frequency)
+    if not r then
+        return
+    end
+
+    local throttle
+    if frequency and frequency > 0 then
+        throttle = 0.25/frequency*0.01
+    else
+        throttle = 0.01
+    end
+    if r._ButtonGlow then
+        local f = r._ButtonGlow
+        local width,height = r:GetSize()
+        f:SetSize(width*1.4 , height*1.4)
+        f:SetPoint("TOPLEFT", r, "TOPLEFT", -width * 0.2, height * 0.2)
+        f:SetPoint("BOTTOMRIGHT", r, "BOTTOMRIGHT", width * 0.2, -height * 0.2)
+        f.ants:SetSize(width*1.4*0.85, height*1.4*0.85)		
+		AnimIn_OnFinished(f.animIn)
+		if f.animOut:IsPlaying() then
+            f.animOut:Stop()
+            f.animIn:Play()
+        end
+		
+        if not(color) then
+            for texture in pairs(ButtonGlowTextures) do
+                f[texture]:SetDesaturated(nil)
+                f[texture]:SetVertexColor(1,1,1)
+                f[texture]:SetAlpha(f[texture]:GetAlpha()/(f.color and f.color[4] or 1))
+                updateAlphaAnim(f, 1)
+            end
+            f.color = false
+        else
+            for texture in pairs(ButtonGlowTextures) do
+                f[texture]:SetDesaturated(1)
+                f[texture]:SetVertexColor(color[1],color[2],color[3])
+                f[texture]:SetAlpha(f[texture]:GetAlpha()/(f.color and f.color[4] or 1)*color[4])
+                updateAlphaAnim(f,color and color[4] or 1)
+            end
+            f.color = color
+        end
+        f.throttle = throttle
+    else
+        local f, new = ButtonGlowPool:Acquire()
+        if new then
+            configureButtonGlow(f,color and color[4] or 1)
+        else
+            updateAlphaAnim(f,color and color[4] or 1)
+        end
+        r._ButtonGlow = f
+        local width,height = r:GetSize()
+        f:SetParent(r)
+        f:SetFrameLevel(r:GetFrameLevel()+8)
+        f:SetSize(width * 1.4, height * 1.4)
+        f:SetPoint("TOPLEFT", r, "TOPLEFT", -width * 0.2, height * 0.2)
+        f:SetPoint("BOTTOMRIGHT", r, "BOTTOMRIGHT", width * 0.2, -height * 0.2)
+        if not(color) then
+            f.color = false
+            for texture in pairs(ButtonGlowTextures) do
+                f[texture]:SetDesaturated(nil)
+                f[texture]:SetVertexColor(1,1,1)
+            end
+        else
+            f.color = color
+            for texture in pairs(ButtonGlowTextures) do
+                f[texture]:SetDesaturated(1)
+                f[texture]:SetVertexColor(color[1],color[2],color[3])
+            end
+        end
+        f.throttle = throttle
+        f:SetScript("OnUpdate", bgUpdate)
+
+        f.animIn:Play()
+
+        if Masque and Masque.UpdateSpellAlert and (not r.overlay or not issecurevariable(r, "overlay")) then
+            local old_overlay = r.overlay
+            r.overlay = f
+            Masque:UpdateSpellAlert(r)
+            r.overlay = old_overlay
+        end
+    end
+end
+
+function lib.ButtonGlow_Stop(r)
+    if r._ButtonGlow then
+        if r._ButtonGlow.animIn:IsPlaying() then
+            r._ButtonGlow.animIn:Stop()
+            ButtonGlowPool:Release(r._ButtonGlow)
+        elseif r:IsVisible() then
+            r._ButtonGlow.animOut:Play()
+        else
+            ButtonGlowPool:Release(r._ButtonGlow)
+        end
+    end
+end
+
+table.insert(lib.glowList, "Action Button Glow")
+lib.startList["Action Button Glow"] = lib.ButtonGlow_Start
+lib.stopList["Action Button Glow"] = lib.ButtonGlow_Stop

--- a/libs/LibCustomGlow-1.0/LibCustomGlow-1.0.toc
+++ b/libs/LibCustomGlow-1.0/LibCustomGlow-1.0.toc
@@ -1,0 +1,12 @@
+## Interface: 80100
+## Title: Lib: CustomGlow
+## Notes: Creates custom glow functions
+## Author: deezo
+## X-Category: Library
+## X-License: BSD
+## Version: 1.0.0
+## OptionalDeps: Masque
+
+LibStub\LibStub.lua
+
+LibCustomGlow-1.0.xml

--- a/libs/LibCustomGlow-1.0/LibCustomGlow-1.0.xml
+++ b/libs/LibCustomGlow-1.0/LibCustomGlow-1.0.xml
@@ -1,0 +1,4 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+  <Script file = "LibCustomGlow-1.0.lua"/>
+</Ui>

--- a/libs/LibCustomGlow-1.0/LibStub/LibStub.lua
+++ b/libs/LibCustomGlow-1.0/LibStub/LibStub.lua
@@ -1,0 +1,51 @@
+-- $Id: LibStub.lua 103 2014-10-16 03:02:50Z mikk $
+-- LibStub is a simple versioning stub meant for use in Libraries.  http://www.wowace.com/addons/libstub/ for more info
+-- LibStub is hereby placed in the Public Domain
+-- Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel, joshborke
+local LIBSTUB_MAJOR, LIBSTUB_MINOR = "LibStub", 2  -- NEVER MAKE THIS AN SVN REVISION! IT NEEDS TO BE USABLE IN ALL REPOS!
+local LibStub = _G[LIBSTUB_MAJOR]
+
+-- Check to see is this version of the stub is obsolete
+if not LibStub or LibStub.minor < LIBSTUB_MINOR then
+	LibStub = LibStub or {libs = {}, minors = {} }
+	_G[LIBSTUB_MAJOR] = LibStub
+	LibStub.minor = LIBSTUB_MINOR
+	
+	-- LibStub:NewLibrary(major, minor)
+	-- major (string) - the major version of the library
+	-- minor (string or number ) - the minor version of the library
+	-- 
+	-- returns nil if a newer or same version of the lib is already present
+	-- returns empty library object or old library object if upgrade is needed
+	function LibStub:NewLibrary(major, minor)
+		assert(type(major) == "string", "Bad argument #2 to `NewLibrary' (string expected)")
+		minor = assert(tonumber(strmatch(minor, "%d+")), "Minor version must either be a number or contain a number.")
+		
+		local oldminor = self.minors[major]
+		if oldminor and oldminor >= minor then return nil end
+		self.minors[major], self.libs[major] = minor, self.libs[major] or {}
+		return self.libs[major], oldminor
+	end
+	
+	-- LibStub:GetLibrary(major, [silent])
+	-- major (string) - the major version of the library
+	-- silent (boolean) - if true, library is optional, silently return nil if its not found
+	--
+	-- throws an error if the library can not be found (except silent is set)
+	-- returns the library object if found
+	function LibStub:GetLibrary(major, silent)
+		if not self.libs[major] and not silent then
+			error(("Cannot find a library instance of %q."):format(tostring(major)), 2)
+		end
+		return self.libs[major], self.minors[major]
+	end
+	
+	-- LibStub:IterateLibraries()
+	-- 
+	-- Returns an iterator for the currently registered libraries
+	function LibStub:IterateLibraries() 
+		return pairs(self.libs) 
+	end
+	
+	setmetatable(LibStub, { __call = LibStub.GetLibrary })
+end

--- a/libs/LibCustomGlow-1.0/LibStub/LibStub.toc
+++ b/libs/LibCustomGlow-1.0/LibStub/LibStub.toc
@@ -1,0 +1,9 @@
+## Interface: 80000
+## Title: Lib: LibStub
+## Notes: Universal Library Stub
+## Credits: Kaelten, Cladhaire, ckknight, Mikk, Ammo, Nevcairiel
+## X-Website: http://www.wowace.com/addons/libstub/
+## X-Category: Library
+## X-License: Public Domain
+
+LibStub.lua

--- a/libs/LibCustomGlow-1.0/LibStub/tests/test.lua
+++ b/libs/LibCustomGlow-1.0/LibStub/tests/test.lua
@@ -1,0 +1,41 @@
+debugstack = debug.traceback
+strmatch = string.match
+
+loadfile("../LibStub.lua")()
+
+local lib, oldMinor = LibStub:NewLibrary("Pants", 1) -- make a new thingy
+assert(lib) -- should return the library table
+assert(not oldMinor) -- should not return the old minor, since it didn't exist
+
+-- the following is to create data and then be able to check if the same data exists after the fact
+function lib:MyMethod()
+end
+local MyMethod = lib.MyMethod
+lib.MyTable = {}
+local MyTable = lib.MyTable
+
+local newLib, newOldMinor = LibStub:NewLibrary("Pants", 1) -- try to register a library with the same version, should silently fail
+assert(not newLib) -- should not return since out of date
+
+local newLib, newOldMinor = LibStub:NewLibrary("Pants", 0) -- try to register a library with a previous, should silently fail
+assert(not newLib) -- should not return since out of date
+
+local newLib, newOldMinor = LibStub:NewLibrary("Pants", 2) -- register a new version
+assert(newLib) -- library table
+assert(rawequal(newLib, lib)) -- should be the same reference as the previous
+assert(newOldMinor == 1) -- should return the minor version of the previous version
+
+assert(rawequal(lib.MyMethod, MyMethod)) -- verify that values were saved
+assert(rawequal(lib.MyTable, MyTable)) -- verify that values were saved
+
+local newLib, newOldMinor = LibStub:NewLibrary("Pants", "Blah 3 Blah") -- register a new version with a string minor version (instead of a number)
+assert(newLib) -- library table
+assert(newOldMinor == 2) -- previous version was 2
+
+local newLib, newOldMinor = LibStub:NewLibrary("Pants", "Blah 4 and please ignore 15 Blah") -- register a new version with a string minor version (instead of a number)
+assert(newLib)
+assert(newOldMinor == 3) -- previous version was 3 (even though it gave a string)
+
+local newLib, newOldMinor = LibStub:NewLibrary("Pants", 5) -- register a new library, using a normal number instead of a string
+assert(newLib)
+assert(newOldMinor == 4) -- previous version was 4 (even though it gave a string)

--- a/libs/LibCustomGlow-1.0/LibStub/tests/test2.lua
+++ b/libs/LibCustomGlow-1.0/LibStub/tests/test2.lua
@@ -1,0 +1,27 @@
+debugstack = debug.traceback
+strmatch = string.match
+
+loadfile("../LibStub.lua")()
+
+for major, library in LibStub:IterateLibraries() do
+	-- check that MyLib doesn't exist yet, by iterating through all the libraries
+	assert(major ~= "MyLib")
+end
+
+assert(not LibStub:GetLibrary("MyLib", true)) -- check that MyLib doesn't exist yet by direct checking
+assert(not pcall(LibStub.GetLibrary, LibStub, "MyLib")) -- don't silently fail, thus it should raise an error.
+local lib = LibStub:NewLibrary("MyLib", 1) -- create the lib
+assert(lib) -- check it exists
+assert(rawequal(LibStub:GetLibrary("MyLib"), lib)) -- verify that :GetLibrary("MyLib") properly equals the lib reference
+
+assert(LibStub:NewLibrary("MyLib", 2))	-- create a new version
+
+local count=0
+for major, library in LibStub:IterateLibraries() do
+	-- check that MyLib exists somewhere in the libraries, by iterating through all the libraries
+	if major == "MyLib" then -- we found it!
+		count = count +1
+		assert(rawequal(library, lib)) -- verify that the references are equal
+	end
+end
+assert(count == 1) -- verify that we actually found it, and only once

--- a/libs/LibCustomGlow-1.0/LibStub/tests/test3.lua
+++ b/libs/LibCustomGlow-1.0/LibStub/tests/test3.lua
@@ -1,0 +1,14 @@
+debugstack = debug.traceback
+strmatch = string.match
+
+loadfile("../LibStub.lua")()
+
+local proxy = newproxy() -- non-string
+
+assert(not pcall(LibStub.NewLibrary, LibStub, proxy, 1)) -- should error, proxy is not a string, it's userdata
+local success, ret = pcall(LibStub.GetLibrary, proxy, true)
+assert(not success or not ret) -- either error because proxy is not a string or because it's not actually registered.
+
+assert(not pcall(LibStub.NewLibrary, LibStub, "Something", "No number in here")) -- should error, minor has no string in it.
+
+assert(not LibStub:GetLibrary("Something", true)) -- shouldn't've created it from the above statement

--- a/libs/LibCustomGlow-1.0/LibStub/tests/test4.lua
+++ b/libs/LibCustomGlow-1.0/LibStub/tests/test4.lua
@@ -1,0 +1,41 @@
+debugstack = debug.traceback
+strmatch = string.match
+
+loadfile("../LibStub.lua")()
+
+
+-- Pretend like loaded libstub is old and doesn't have :IterateLibraries
+assert(LibStub.minor)
+LibStub.minor = LibStub.minor - 0.0001
+LibStub.IterateLibraries = nil
+
+loadfile("../LibStub.lua")()
+
+assert(type(LibStub.IterateLibraries)=="function")
+
+
+-- Now pretend that we're the same version -- :IterateLibraries should NOT be re-created
+LibStub.IterateLibraries = 123
+
+loadfile("../LibStub.lua")()
+
+assert(LibStub.IterateLibraries == 123)
+
+
+-- Now pretend that a newer version is loaded -- :IterateLibraries should NOT be re-created
+LibStub.minor = LibStub.minor + 0.0001
+
+loadfile("../LibStub.lua")()
+
+assert(LibStub.IterateLibraries == 123)
+
+
+-- Again with a huge number
+LibStub.minor = LibStub.minor + 1234567890
+
+loadfile("../LibStub.lua")()
+
+assert(LibStub.IterateLibraries == 123)
+
+
+print("OK")

--- a/libs/libs.xml
+++ b/libs/libs.xml
@@ -16,6 +16,7 @@
 	<Include file="AceSerializer-3.0\AceSerializer-3.0.xml"/>
 	<Include file="LibCompress\lib.xml"/>
 	<Include file="LibDeflate\lib.xml"/>
+	<Include file="LibCustomGlow-1.0\LibCustomGlow-1.0.xml"/>
 	<Script file="LibDataBroker-1.1\LibDataBroker-1.1.lua"/>
 	<Script file="LibDBIcon-1.0\LibDBIcon-1.0.lua"/>
 	<Script file="indent.lua"/>


### PR DESCRIPTION
Adding LibCustomGlow-1.0 and Plater functions to create glow effects on frames based on the lib.
Test-Mod for target glows: https://wago.io/ax6AS_lYG

Adds the following functions:
- Plater.StartGlow(frame, color, options, key) -- start glow effect according to options, defaults to "button"
- Plater.StartAntsGlow(frame, color, options, key) -- start "ants" glow
- Plater.StartPixelGlow(frame, color, options, key) -- start "pixel" glow
- Plater.StartButtonGlow(frame, color, options, key) -- start "button" glow

- Plater.StopGlow(unitFrame.healthBar, glowType, key) -- stop all glow effects or a specific one
- Plater.StopAntsGlow(frame, key) -- stop an ants glow
- Plater.StopPixelGlow(frame, key) -- stop a pixel glow
- Plater.StopButtonGlow(frame, key) -- stop a button glow


Options documentation:
	--[[ options can be used to create different glow types, see https://www.curseforge.com/wow/addons/libcustomglow

		--type "pixel"
		options = {
			glowType = "pixel",
			color = "white", -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
			N = 8, -- number of lines. Defaul value is 8;
			frequency = 0.25, -- frequency, set to negative to inverse direction of rotation. Default value is 0.25;
			length = 4, -- length of lines. Default value depends on region size and number of lines;
			th = 2, -- thickness of lines. Default value is 2;
			xOffset = 0,
			yOffset = 0, -- offset of glow relative to region border;
			border = false, -- set to true to create border under lines;
			key = "", -- key of glow, allows for multiple glows on one frame;
		}
		
		-- type "ants"
		options = {
			glowType = "ants",
			color = "white", -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
			N = 4, -- number of particle groups. Each group contains 4 particles. Defaul value is 4;
			frequency = 0.125, -- frequency, set to negative to inverse direction of rotation. Default value is 0.125;
			scale = 1, -- scale of particles
			xOffset = 0,
			yOffset = 0, -- offset of glow relative to region border;
			key = "", -- key of glow, allows for multiple glows on one frame;
		}
		
		-- type "button"
		options = {
			glowType = "button",
			color = "white", -- all plater color types accepted, from lib: {r,g,b,a}, color of lines and opacity, from 0 to 1. Defaul value is {0.95, 0.95, 0.32, 1}
			frequency = 0.125, -- frequency, set to negative to inverse direction of rotation. Default value is 0.125;
		}
	--]]