### PR TITLE
- adding IsProtected function to Plater namepaltes

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -9357,7 +9357,18 @@ end
 					end
 				end
 			end
-		end
+		end,
+		
+		IsProtected = function (self)
+		-- assume that nameplates are always protected since 8.2
+			if self then
+				if self.PlateFrame then
+					return self.PlateFrame:IsProtected()
+				end
+			end
+			
+			return false
+		end,
 	}
 	 
 	function Plater.GetAllScripts (scriptType)


### PR DESCRIPTION
This enables addons like MoveAnything to correctly gather information about the protected status of the frame. This might need to be added for child-frames as well.