### PR TITLE
- add "solo" options for threat colors

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -5671,7 +5671,11 @@ end
 			--dps
 			if (isTanking) then
 				--the player is tanking as dps
-				set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.aggro))
+				if Plater.db.profile.dps.use_aggro_solo and not IsInGroup() then
+					set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.solo))
+				else
+					set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.aggro))
+				end
 				if (not self.PlateFrame.playerHasAggro and IS_IN_INSTANCE) then
 					self.PlateFrame.PlayBodyFlash ("-AGGRO-")
 				end
@@ -5714,14 +5718,22 @@ end
 					end
 				else
 					if (threatStatus == 3) then --player is tanking the mob as dps
-						set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.aggro))
+						if Plater.db.profile.dps.use_aggro_solo and not IsInGroup() then
+							set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.solo))
+						else
+							set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.aggro))
+						end
 						if (not self.PlateFrame.playerHasAggro and IS_IN_INSTANCE) then
 							self.PlateFrame.PlayBodyFlash ("-AGGRO-")
 						end
 						self.PlateFrame.playerHasAggro = true
 						
 					elseif (threatStatus == 2) then --player is tanking the mob with low aggro
-						set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.aggro))
+						if Plater.db.profile.dps.use_aggro_solo and not IsInGroup() then
+							set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.solo))
+						else
+							set_aggro_color (self, unpack (DB_AGGRO_DPS_COLORS.aggro))
+						end
 						self.PlateFrame.playerHasAggro = true
 						
 					else --the unit isn't attacking the player based on the threat situation
@@ -5733,7 +5745,11 @@ end
 							--show aggro warning indicators
 							self.aggroGlowUpper:Show()
 							self.aggroGlowLower:Show()
-							colorToUse = DB_AGGRO_DPS_COLORS.pulling
+							if Plater.db.profile.dps.use_aggro_solo and not IsInGroup() then
+								colorToUse = DB_AGGRO_DPS_COLORS.solo
+							else
+								colorToUse = DB_AGGRO_DPS_COLORS.pulling
+							end
 							
 						elseif (threatStatus == 0) then
 							colorToUse = DB_AGGRO_DPS_COLORS.noaggro

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -2398,10 +2398,12 @@ PLATER_DEFAULT_SETTINGS = {
 		dps = {
 			colors = {
 				aggro = {1, 0.109803, 0},
+				solo = {.5, .5, 1},
 				noaggro = {.5, .5, 1},
 				pulling = {1, .8, 0},
 				notontank = {.5, .5, 1}, --color inside dungeon when the mob is not in the tank aggro and not on the player
 			},
+			use_aggro_solo = false,
 		},
 		
 		news_frame = {},

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -10358,6 +10358,30 @@ local relevance_options = {
 			desc = L["OPTIONS_THREAT_COLOR_DPS_NOAGGRO_DESC"],
 		},
 		
+		{
+			type = "toggle",
+			get = function() return Plater.db.profile.dps.use_aggro_solo end,
+			set = function (self, fixedparam, value) 
+				Plater.db.profile.dps.use_aggro_solo = value
+			end,
+			name = "Use 'Solo' color",
+			desc = "Use the 'Solo' color when not in a group.",
+		},
+		
+		{
+			type = "color",
+			get = function()
+				local color = Plater.db.profile.dps.colors.solo
+				return {color[1], color[2], color[3], color[4]}
+			end,
+			set = function (self, r, g, b, a) 
+				local color = Plater.db.profile.dps.colors.solo
+				color[1], color[2], color[3], color[4] = r, g, b, a
+			end,
+			name = "Solo",
+			desc = "If enabled, always use this color when not in a group.",
+		},
+		
 		{type = "blank"},
 		{
 			type = "toggle",


### PR DESCRIPTION
Adding a "solo" color for DPS which can be toggled on to overwrite all other threat state colors when not grouped. This adresses feature request #34.