### PR TITLE
- fixing bug with spell-animation settings

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -1425,9 +1425,10 @@ Plater.DefaultSpellRangeList = {
 							tinsert (frameAnimations, data)
 						end
 					end
+					
+					SPELL_WITH_ANIMATIONS [spellName] = frameAnimations
 				end
 				
-				SPELL_WITH_ANIMATIONS [spellName] = frameAnimations
 			end
 		end
 


### PR DESCRIPTION
If a spell for an animation is not found, it would throw a nil-error. This can happen with old profiles if the spell has been removed from the game.