### PR TITLE
- fixing spell cast delayed event hiding the castbar in some cases

### DIFF
--- a/libs/DF/fw.lua
+++ b/libs/DF/fw.lua
@@ -1,5 +1,5 @@
 
-local dversion = 154
+local dversion = 155
 local major, minor = "DetailsFramework-1.0", dversion
 local DF, oldminor = LibStub:NewLibrary (major, minor)
 

--- a/libs/DF/panel.lua
+++ b/libs/DF/panel.lua
@@ -7683,7 +7683,7 @@ DF.CastFrameFunctions = {
 		--> check max value
 		if (not isFinished and not self.finished) then
 			if (self.casting) then
-				if (self.value >= self.maxValue or self.value < 0) then
+				if (self.value >= self.maxValue) then
 					isFinished = true
 				end
 				
@@ -8287,8 +8287,10 @@ DF.CastFrameFunctions = {
 		self.spellStartTime = startTime / 1000
 		self.spellEndTime = endTime / 1000
 		self.value = GetTime() - self.spellStartTime
+		if self.value < 0 then self.value = 0 end
 		self.maxValue = self.spellEndTime - self.spellStartTime
 		self:SetMinMaxValues (0, self.maxValue)
+		self:SetValue (self.value)
 	end,
 
 	UNIT_SPELLCAST_CHANNEL_UPDATE = function (self, unit, ...)


### PR DESCRIPTION
The UNIT_SPELLCAST_DELAYED event could hide the castbar if the pased cast time was lower than the push back amount.