### PR TITLE
Add alpha to SetNameplateColor

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -4553,8 +4553,8 @@ end
 	--internal function to change the health bar color
 	function Plater.ChangeHealthBarColor_Internal (healthBar, r, g, b, a, forceNoLerp) --private
 		a = a or 1
-		if (r ~= healthBar.R or g ~= healthBar.G or b ~= healthBar.B or a ~= healthBar.A) then
-			healthBar.R, healthBar.G, healthBar.B, healthBar.A = r, g, b, a
+		if (r ~= healthBar.R or g ~= healthBar.G or b ~= healthBar.B) then
+			healthBar.R, healthBar.G, healthBar.B = r, g, b
 			if (not DB_LERP_COLOR or forceNoLerp) then -- ~lerpcolor
 				healthBar.barTexture:SetVertexColor (r, g, b, a)
 			end

--- a/Plater.lua
+++ b/Plater.lua
@@ -4355,7 +4355,7 @@ function Plater.OnInit() --private --~oninit ~init
 			if (plateFrame.PlateConfig.healthbar_color_by_hp) then
 				local originalColor = plateFrame.PlateConfig.healthbar_color
 				local r, g, b = DF:LerpLinearColor (abs (currentHealth / currentHealthMax - 1), 1, originalColor[1], originalColor[2], originalColor[3], 1, .4, 0)
-				Plater.ChangeHealthBarColor_Internal (self, r, g, b, originalColor[4] or 1, true)
+				Plater.ChangeHealthBarColor_Internal (self, r, g, b, (originalColor[4] or 1), true)
 			end
 			
 			Plater.CheckLifePercentText (unitFrame)
@@ -4552,9 +4552,7 @@ end
 	
 	--internal function to change the health bar color
 	function Plater.ChangeHealthBarColor_Internal (healthBar, r, g, b, a, forceNoLerp) --private
-		if (a == nil) then
-			a = 1
-		end
+		a = a or 1
 		if (r ~= healthBar.R or g ~= healthBar.G or b ~= healthBar.B or a ~= healthBar.A) then
 			healthBar.R, healthBar.G, healthBar.B, healthBar.A = r, g, b, a
 			if (not DB_LERP_COLOR or forceNoLerp) then -- ~lerpcolor

--- a/Plater.lua
+++ b/Plater.lua
@@ -1678,12 +1678,12 @@ Plater.DefaultSpellRangeListF = {
 			local colorID = infoTable [3] --the color
 			
 			if (enabled1 and not enabled2) then
-				local r, g, b = DF:ParseColors (colorID)
-				DB_UNITCOLOR_CACHE [npcID] = {r, g, b, 1}
+				local r, g, b, a = DF:ParseColors (colorID)
+				DB_UNITCOLOR_CACHE [npcID] = {r, g, b, a}
 				
 			elseif (enabled1 and enabled2) then
-				local r, g, b = DF:ParseColors (colorID)
-				DB_UNITCOLOR_SCRIPT_CACHE [npcID] = {r, g, b, 1}
+				local r, g, b, a = DF:ParseColors (colorID)
+				DB_UNITCOLOR_SCRIPT_CACHE [npcID] = {r, g, b, a}
 				
 			end
 		end
@@ -4355,7 +4355,7 @@ function Plater.OnInit() --private --~oninit ~init
 			if (plateFrame.PlateConfig.healthbar_color_by_hp) then
 				local originalColor = plateFrame.PlateConfig.healthbar_color
 				local r, g, b = DF:LerpLinearColor (abs (currentHealth / currentHealthMax - 1), 1, originalColor[1], originalColor[2], originalColor[3], 1, .4, 0)
-				Plater.ChangeHealthBarColor_Internal (self, r, g, b, true)
+				Plater.ChangeHealthBarColor_Internal (self, r, g, b, originalColor[4], true)
 			end
 			
 			Plater.CheckLifePercentText (unitFrame)
@@ -4512,7 +4512,7 @@ end
 				--there's a bug here where quest_color is nil for a friendly npc
 				--this is happening when an enemy quest npc turns friendly and (probably) the actorType doesn't change
 				--so in the enemy npc settings table does not have 'quest_color' input
-				Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, unpack (DB_PLATE_CONFIG [unitFrame.ActorType].quest_color or {.5, 1, 0}))
+				Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, unpack (DB_PLATE_CONFIG [unitFrame.ActorType].quest_color or {.5, 1, 0, 1}))
 			end
 		end
 	end
@@ -4528,8 +4528,8 @@ end
 				local reaction = unitFrame [MEMBER_REACTION]
 				--has a valid reaction
 				if (reaction) then
-					local r, g, b = unpack (Plater.db.profile.color_override_colors [reaction])
-					Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, r, g, b, true)
+					local r, g, b, a = unpack (Plater.db.profile.color_override_colors [reaction])
+					Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, r, g, b, a, true)
 				end
 			else
 				--unit is a quest mob, reset the color to quest color
@@ -4551,11 +4551,11 @@ end
 	end
 	
 	--internal function to change the health bar color
-	function Plater.ChangeHealthBarColor_Internal (healthBar, r, g, b, forceNoLerp) --private
-		if (r ~= healthBar.R or g ~= healthBar.G or b ~= healthBar.B) then
-			healthBar.R, healthBar.G, healthBar.B = r, g, b
+	function Plater.ChangeHealthBarColor_Internal (healthBar, r, g, b, a, forceNoLerp) --private
+		if (r ~= healthBar.R or g ~= healthBar.G or b ~= healthBar.B or a ~= healthBar.A) then
+			healthBar.R, healthBar.G, healthBar.B, healthBar.A = r, g, b, a
 			if (not DB_LERP_COLOR or forceNoLerp) then -- ~lerpcolor
-				healthBar.barTexture:SetVertexColor (r, g, b)
+				healthBar.barTexture:SetVertexColor (r, g, b, a)
 			end
 		end
 	end
@@ -4563,7 +4563,7 @@ end
 	--do several checkes to determine which are the color of this nameplate
 	--if force refresh is true, it'll ignore aggro and incombat checks in the ColorOverrider function
 	function Plater.FindAndSetNameplateColor (unitFrame, forceRefresh)
-		local r, g, b = 1, 1, 1
+		local r, g, b, a = 1, 1, 1, 1
 		local unitID = unitFrame.unit
 		if (unitFrame.IsSelf) then
 			return
@@ -4576,26 +4576,26 @@ end
 						local _, class = UnitClass (unitID)
 						local classColor = RAID_CLASS_COLORS [class]
 						if (classColor) then -- and unitFrame.optionTable.useClassColors
-							r, g, b = classColor.r, classColor.g, classColor.b
+							r, g, b, a = classColor.r, classColor.g, classColor.b, classColor.a
 						end
 					else
-						r, g, b = unpack(Plater.db.profile.plate_config.friendlyplayer.fixed_class_color)
+						r, g, b, a = unpack(Plater.db.profile.plate_config.friendlyplayer.fixed_class_color)
 					end
 				elseif (unitFrame.ActorType == ACTORTYPE_ENEMY_PLAYER) then
 					if (Plater.db.profile.plate_config.enemyplayer.use_playerclass_color) then
 						local _, class = UnitClass (unitID)
 						local classColor = RAID_CLASS_COLORS [class]
 						if (classColor) then -- and unitFrame.optionTable.useClassColors
-							r, g, b = classColor.r, classColor.g, classColor.b
+							r, g, b, a = classColor.r, classColor.g, classColor.b, classColor.a
 						end
 					else
-						r, g, b = unpack(Plater.db.profile.plate_config.enemyplayer.fixed_class_color)
+						r, g, b, a = unpack(Plater.db.profile.plate_config.enemyplayer.fixed_class_color)
 					end
 				end
 				
 			--check if is tapped
 			elseif (Plater.IsUnitTapDenied (unitID)) then
-				r, g, b = unpack (Plater.db.profile.tap_denied_color)
+				r, g, b, a = unpack (Plater.db.profile.tap_denied_color)
 
 			else
 				if (Plater.CanOverrideColor) then
@@ -4610,11 +4610,11 @@ end
 				end
 				
 				--get the color from the client
-				r, g, b = UnitSelectionColor (unitID)
+				r, g, b, a = UnitSelectionColor (unitID)
 			end
 		end
 		
-		Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, r, g, b, true)
+		Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, r, g, b, a, true)
 	end
 
 	--force an update on all nameplates showin in the screen
@@ -5173,9 +5173,9 @@ end
 		Plater.EndLogPerformanceCore("Plater-Core", "Update", "NameplateTick")
 	end
 	
-	local set_aggro_color = function (self, r, g, b) --self = unitName
+	local set_aggro_color = function (self, r, g, b, a) --self = unitName
 		if (DB_AGGRO_CHANGE_HEALTHBAR_COLOR) then	
-			Plater.ChangeHealthBarColor_Internal (self.healthBar, r, g, b)
+			Plater.ChangeHealthBarColor_Internal (self.healthBar, r, g, b, a)
 		end
 		
 		if (DB_AGGRO_CHANGE_BORDER_COLOR) then
@@ -6413,9 +6413,9 @@ end
 				local _, class = UnitClass (unitFrame [MEMBER_UNITID])
 				if (class) then		
 					local color = RAID_CLASS_COLORS [class]
-					Plater.ChangeHealthBarColor_Internal (healthBar, color.r, color.g, color.b)
+					Plater.ChangeHealthBarColor_Internal (healthBar, color.r, color.g, color.b, color.a)
 				else
-					Plater.ChangeHealthBarColor_Internal (healthBar, 1, 1, 1)
+					Plater.ChangeHealthBarColor_Internal (healthBar, 1, 1, 1, 1)
 				end
 			end
 			
@@ -6441,7 +6441,7 @@ end
 						local _, class = UnitClass (unitFrame [MEMBER_UNITID])
 						if (class) then		
 							local color = RAID_CLASS_COLORS [class]
-							Plater.ChangeHealthBarColor_Internal (healthBar, color.r, color.g, color.b)
+							Plater.ChangeHealthBarColor_Internal (healthBar, color.r, color.g, color.b, color.a)
 						else
 							Plater.ChangeHealthBarColor_Internal (healthBar, unpack (DB_PLATE_CONFIG [actorType].fixed_class_color))
 						end
@@ -8555,13 +8555,13 @@ end
 	end
 
 	--modify the color of the health bar
-	function Plater.SetNameplateColor (unitFrame, r, g, b)
+	function Plater.SetNameplateColor (unitFrame, r, g, b, a)
 		if (unitFrame.unit) then
 			if (not r) then
 				Plater.RefreshNameplateColor (unitFrame)
 			else
-				r, g, b = DF:ParseColors (r, g, b)
-				return Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, r, g, b)
+				r, g, b, a = DF:ParseColors (r, g, b, a)
+				return Plater.ChangeHealthBarColor_Internal (unitFrame.healthBar, r, g, b, a)
 			end
 		end
 	end
@@ -10876,7 +10876,7 @@ end
 		Plater.DebugColorAnimation_Timer = C_Timer.NewTicker (0.5, function() --~animationtest
 			for _, plateFrame in ipairs (Plater.GetAllShownPlates()) do
 				--make the bar jump from green to pink - pink to green
-				Plater.ChangeHealthBarColor_Internal (plateFrame.unitFrame.healthBar, math.abs (math.sin (GetTime())), math.abs (math.cos (GetTime())), math.abs (math.sin (GetTime())))
+				Plater.ChangeHealthBarColor_Internal (plateFrame.unitFrame.healthBar, math.abs (math.sin (GetTime())), math.abs (math.cos (GetTime())), math.abs (math.sin (GetTime())), 1)
 			end
 		end)
 

--- a/Plater.lua
+++ b/Plater.lua
@@ -4355,7 +4355,7 @@ function Plater.OnInit() --private --~oninit ~init
 			if (plateFrame.PlateConfig.healthbar_color_by_hp) then
 				local originalColor = plateFrame.PlateConfig.healthbar_color
 				local r, g, b = DF:LerpLinearColor (abs (currentHealth / currentHealthMax - 1), 1, originalColor[1], originalColor[2], originalColor[3], 1, .4, 0)
-				Plater.ChangeHealthBarColor_Internal (self, r, g, b, originalColor[4], true)
+				Plater.ChangeHealthBarColor_Internal (self, r, g, b, originalColor[4] or 1, true)
 			end
 			
 			Plater.CheckLifePercentText (unitFrame)
@@ -4552,6 +4552,9 @@ end
 	
 	--internal function to change the health bar color
 	function Plater.ChangeHealthBarColor_Internal (healthBar, r, g, b, a, forceNoLerp) --private
+		if (a == nil) then
+			a = 1
+		end
 		if (r ~= healthBar.R or g ~= healthBar.G or b ~= healthBar.B or a ~= healthBar.A) then
 			healthBar.R, healthBar.G, healthBar.B, healthBar.A = r, g, b, a
 			if (not DB_LERP_COLOR or forceNoLerp) then -- ~lerpcolor

--- a/Plater_DefaultSettings.lua
+++ b/Plater_DefaultSettings.lua
@@ -96,7 +96,7 @@ PLATER_DEFAULT_SETTINGS = {
 				click_through = true,
 				show_guild_name = false,
 				
-				fixed_class_color = {0, 1, 0},
+				fixed_class_color = {0, 1, 0, 1},
 				
 				health = {70, 2},
 				health_incombat = {70, 2},
@@ -167,7 +167,7 @@ PLATER_DEFAULT_SETTINGS = {
 				show_guild_name = false,
 				
 				use_playerclass_color = true,
-				fixed_class_color = {1, .4, .1},
+				fixed_class_color = {1, .4, .1, 1},
 				
 				health = {112, 12},
 				cast = {112, 10},
@@ -312,7 +312,7 @@ PLATER_DEFAULT_SETTINGS = {
 				percent_text_alpha = 1,
 				
 				quest_enabled = true,
-				quest_color = {.5, 1, 0},
+				quest_color = {.5, 1, 0, 1},
 				
 				big_actortitle_text_size = 11,
 				big_actortitle_text_font = "Arial Narrow",
@@ -394,8 +394,8 @@ PLATER_DEFAULT_SETTINGS = {
 				percent_text_alpha = 1,
 				
 				quest_enabled = true,
-				quest_color_enemy = {1, .369, 0},
-				quest_color_neutral = {1, .65, 0},
+				quest_color_enemy = {1, .369, 0, 1},
+				quest_color_neutral = {1, .65, 0, 1},
 				
 				--no color / it'll auto colour by the reaction
 				big_actortitle_text_size = 10,
@@ -2502,7 +2502,7 @@ PLATER_DEFAULT_SETTINGS = {
 		focus_color = {0, 0, 0, 0.5},
 		focus_texture = "PlaterFocus",
 		
-		tap_denied_color = {.9, .9, .9},
+		tap_denied_color = {.9, .9, .9, 1},
 		
 		aggro_modifies = {
 			health_bar_color = true,
@@ -2517,22 +2517,22 @@ PLATER_DEFAULT_SETTINGS = {
 		
 		tank = {
 			colors = {
-				aggro = {.5, .5, 1},
-				noaggro = {1, 0, 0},
-				pulling = {1, 1, 0},
-				nocombat = {0.505, 0.003, 0},
-				anothertank = {0.729, 0.917, 1},
-				pulling_from_tank = {1, .7, 0}, --color when a tank is pulling the aggro from another tank
+				aggro = {.5, .5, 1, 1},
+				noaggro = {1, 0, 0, 1},
+				pulling = {1, 1, 0, 1},
+				nocombat = {0.505, 0.003, 0, 1},
+				anothertank = {0.729, 0.917, 1, 1},
+				pulling_from_tank = {1, .7, 0, 1}, --color when a tank is pulling the aggro from another tank
 			},
 		},
 		
 		dps = {
 			colors = {
-				aggro = {1, 0.109803, 0},
-				solo = {.5, .5, 1},
-				noaggro = {.5, .5, 1},
-				pulling = {1, .8, 0},
-				notontank = {.5, .5, 1}, --color inside dungeon when the mob is not in the tank aggro and not on the player
+				aggro = {1, 0.109803, 0, 1},
+				solo = {.5, .5, 1, 1},
+				noaggro = {.5, .5, 1, 1},
+				pulling = {1, .8, 0, 1},
+				notontank = {.5, .5, 1, 1}, --color inside dungeon when the mob is not in the tank aggro and not on the player
 			},
 			use_aggro_solo = false,
 		},


### PR DESCRIPTION
I inserted a few alpha values of 1 where hardcoded values were set. Other than that, I *think* this should just work. Existing calls that omit the alpha argument shouldn't break.