### PR TITLE
fix extra icon border not showing for offensive / defensive auras

### DIFF
--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -881,11 +881,11 @@ local AUTO_TRACKING_EXTRA_DEBUFFS = {}
 			--> enrage effects
 			borderColor = Plater.db.profile.extra_icon_show_enrage_border
 		
-		elseif (DF.CooldownsAllDeffensive and DF.CooldownsAllDeffensive[spellName]) then 
+		elseif (DF.CooldownsAllDeffensive and DF.CooldownsAllDeffensive[spellId]) then 
 			--> defensive effects
 			borderColor = Plater.db.profile.extra_icon_show_defensive_border
 		
-		elseif (DF.CooldownsAttack and DF.CooldownsAttack[spellName]) then 
+		elseif (DF.CooldownsAttack and DF.CooldownsAttack[spellId]) then 
 			--> offensive effects
 			borderColor = Plater.db.profile.extra_icon_show_offensive_border
 		


### PR DESCRIPTION
Noticed that the custom borders for 'Buff Special' weren't working.

This change updates `Plater.AddExtraIcon` to use the logic found in `Plater.AddAura` when determining offensive / defensive border colors.

Side note, I noticed `Plater.AddAura` uses `DF.CrowdControlSpells[spellId]` for checking if the aura is CC while `Plater.AddExtraIcon` uses `CROWDCONTROL_AURA_NAMES[spellName]`. I couldn't find any other uses of `CROWDCONTROL_AURA_NAMES` - would it make sense to remove `CROWDCONTROL_AURA_NAMES` all together and switch to `DF.CrowdControlSpells`?


Love the addon - thanks for all the work put into it. 
