### PR TITLE
Add function to allow nameplate access to the collected bg information

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -8258,6 +8258,15 @@ end
 			end
 		end
 	end
+
+	function Plater.GetUnitBGInfo(unit)
+		local name = GetUnitName(unit, true)
+		if not BG_PLAYER_CACHE[name] then
+			Plater.UpdateBgPlayerRoleCache()
+		end
+
+		return BG_PLAYER_CACHE[name]
+	end
 	
 	function Plater.GetSpecIconForUnitFromBG(unit)
 		local name = GetUnitName(unit, true)


### PR DESCRIPTION
Add function to allow nameplate access to the collected bg information. This will allow a more accurate healer indicator since we can use the same data used for the spec icon.