### PR TITLE
Bugfix: Call resourceFrame whenever the value is set

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -5163,9 +5163,9 @@ function Plater.OnInit() --private --~oninit ~init
 						alternatePowerFrame:SetParent (targetPlateFrame.unitFrame)
 						alternatePowerFrame:ClearAllPoints()
 						if resourceFrame then
-							resourceFrame:SetPoint ("bottom", targetPlateFrame.unitFrame.healthBar, "top", 0, Plater.db.profile.resources.y_offset_target)
-						else
 							alternatePowerFrame:SetPoint ("bottom", resourceFrame, "top", 0, 2)
+						else
+							alternatePowerFrame:SetPoint ("bottom", targetPlateFrame.unitFrame.healthBar, "top", 0, Plater.db.profile.resources.y_offset_target)
 						end
 						alternatePowerFrame:SetFrameStrata(targetPlateFrame.unitFrame.healthBar:GetFrameStrata())
 						alternatePowerFrame:SetFrameLevel(targetPlateFrame.unitFrame.healthBar:GetFrameLevel() + 25)

--- a/Plater.lua
+++ b/Plater.lua
@@ -5163,9 +5163,9 @@ function Plater.OnInit() --private --~oninit ~init
 						alternatePowerFrame:SetParent (targetPlateFrame.unitFrame)
 						alternatePowerFrame:ClearAllPoints()
 						if resourceFrame then
-							alternatePowerFrame:SetPoint ("bottom", resourceFrame, "top", 0, 2)
-						else
 							resourceFrame:SetPoint ("bottom", targetPlateFrame.unitFrame.healthBar, "top", 0, Plater.db.profile.resources.y_offset_target)
+						else
+							alternatePowerFrame:SetPoint ("bottom", resourceFrame, "top", 0, 2)
 						end
 						alternatePowerFrame:SetFrameStrata(targetPlateFrame.unitFrame.healthBar:GetFrameStrata())
 						alternatePowerFrame:SetFrameLevel(targetPlateFrame.unitFrame.healthBar:GetFrameLevel() + 25)


### PR DESCRIPTION
I've been seeing an error from bug grabber for Plater for the past couple of days only when playing on my brewmaster monk and have traced it down to this part of the code.

It appears that the `resourceFrame` logic is inverted and only tries to call the `resourceFrame` only if the value isn't set which will cause. I believe this only happens on my brewmaster monk as stagger is treated as an `alternatePowerFrame` and it will go down this code path.


This is the full bug grabber output:

```
500x Plater/Plater.lua:5168: attempt to index local 'resourceFrame' (a nil value)
[string "@Plater/Plater.lua"]:5168: in function `UpdateResourceFrame'
[string "@Plater/Plater.lua"]:4991: in function <Plater/Plater.lua:4987>
[string "=(tail call)"]: ?
[string "=[C]"]: in function `SetupClassNameplateBars'
[string "@Blizzard_NamePlates/Blizzard_NamePlates.lua"]:206: in function `OnTargetChanged'
[string "@Blizzard_NamePlates/Blizzard_NamePlates.lua"]:83: in function <...eBlizzard_NamePlates/Blizzard_NamePlates.lua:69>
[string "=[C]"]: in function `CameraOrSelectOrMoveStop'
[string "CAMERAORSELECTORMOVE"]:4: in function <[string "CAMERAORSELECTORMOVE"]:1>

Locals:
showSelf = false
onCurrentTarget = true
resourceFrame = nil
alternatePowerFrame = ClassNameplateBrewmasterBarFrame {
 0 = <userdata>
 UpdateIsAliveState = <function> defined @FrameXML/AlternatePowerBarBase.lua:125
 baseMixin = <table> {
 }
 Border = Frame {
 }
 GetCurrentMinMaxPower = <function> defined @FrameXML/MonkStaggerBar.lua:65
 background = Texture {
 }
 OnUpdate = <function> defined @FrameXML/AlternatePowerBarBase.lua:33
 Texture = Texture {
 }
 OnShow = <function> defined @Blizzard_NamePlates/Blizzard_ClassNameplateAlternatePowerBar.lua:12
 OnBarDisabled = <function> defined @FrameXML/AlternatePowerBarBase.lua:151
 Initialize = <function> defined @Blizzard_NamePlates/Blizzard_ClassNameplateBar_Monk.lua:40
 RemoveBarFromUnitUI = <function> defined @Blizzard_NamePlates/Blizzard_ClassNameplateAlternatePowerBar.lua:23
 OnOptionsUpdated = <function> defined @Blizzard_NamePlates/Blizzard_ClassNameplateAlternatePowerBar.lua:37
 frequentUpdates = true
 UpdateMinMaxPower = <function> defined @FrameXML/AlternatePowerBarBase.lua:100
 scale = "1"
 AttachBarToUnitUI = <function> defined @Blizzard_NamePlates/Blizzard_ClassNameplateAlternatePowerBar.lua:18
 unit = "player"
 requiredClass = "MONK"
 UpdateArt = <function> defined @FrameXML/MonkStaggerBar.lua:26
 minPower = 0
 OnBarEnabled = <function> defined @FrameXML/MonkStaggerBar.lua:57
 overrideArtInfo = <table> {
 }
 OnLoad = <function> defined @FrameXML/AlternatePowerBarBase.lua:6
 requiredSpec = 1
 UpdatePower = <function> defined @FrameXML/MonkStaggerBar.lua:20
 maxPower = 821040
 OnEvent = <function> defined @FrameXML/AlternatePowerBarBase.lua:41
 EvaluateUnit = <function> defined @FrameXML/MonkStaggerBar.lua:48
 GetCurrentPower = <function> defined @FrameXML/MonkStaggerBar.lua:61
 OnSizeChanged = <function> defined @Blizzard_NamePlates/Blizzard_ClassNameplateAlternatePowerBar.lua:41
 powerName = "STAGGER"
 isEnabled = true
 currentPower = 0
 GetUnit = <function> defined @FrameXML/AlternatePowerBarBase.lua:107
 SetBarEnabled = <function> defined @FrameXML/AlternatePowerBarBase.lua:58
}
targetPlateFrame = NamePlate14 {
 0 = <userdata>
 CurrentUnitNameString = FontString {
 }
 isNamePlate = true
 GetAdditionalInsetPadding = <function> defined @Blizzard_NamePlates/Blizzard_NamePlates.lua:587
 namePlateUnitReaction = 4
 PlayBodyFlash = <function> defined @Plater/Plater.lua:9330
 QuestInfo = <table> {
 }
 ApplyOffsets = <function> defined @Blizzard_NamePlates/Blizzard_NamePlates.lua:569
 namePlateUnitGUID = "Creature-0-3883-2444-15103-198594-0000B33645"
 Top3DFrame = NamePlate143DFrame {
 }
 namePlateUnitNameLower = "cleave training dummy"
 unitFramePlater = NamePlate14PlaterUnitFrame {
 }
 isSoftInteract = false
 template = "NamePlateUnitFrameTemplate"
 FocusIndicator = Texture {
 }
 IconIndicators = <table> {
 }
 OnSizeChanged = <function> defined @Blizzard_NamePlates/Blizzard_NamePlates.lua:617
 UnitFrame = Button {
 }
 isObject = false
 isSoftInteractObject = false
 Plater = true
 OnRemoved = <function> defined @Blizzard_NamePlates/Blizzard_NamePlates.lua:556
 NameAnchor = 1
 ActorNameSpecial = FontString {
 }
 OnOptionsUpdated = <function> defined @Blizzard_NamePlates/Blizzard_NamePlates.lua:563
 debugAreaTexture = Texture {
 }
 driverFrame = NamePlateDriverFrame {
 }
 unitFrame = NamePlate14PlaterUnitFrame {
 }
 actorType = "enemynpc"
 playerHasAggro = false
 namePlateNpcId = 198594
 namePlateClassification = "normal"
 unitName = FontString {
 }
 TargetNeonDown = Texture {
 }
 PlayerCannotAttack = false
 RaidTarget = Texture {
 }
 GetPreferredInsets = <function> defined @Blizzard_NamePlates/Blizzard_NamePlates.lua:598
 OnTickFrame = Frame {
 }
 TargetNeonUp = Texture {
 }
 OnAdded = <function> defined @Interface
```