### PR TITLE
Account for ModRate on Aura Update

### DIFF
--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1278,7 +1278,7 @@ end
 	local function AuraIconOnTick_UpdateCooldown (self, deltaTime)
 		local now = GetTime()
 		if (self.lastUpdateCooldown + 0.05) <= now then
-			self.RemainingTime = (self.ExpirationTime - now) / self.ModRate
+			self.RemainingTime = (self.ExpirationTime - now) / (self.ModRate or 1)
 			if self.RemainingTime > 0 then
 				if self.formatWithDecimals then
 					self.Cooldown.Timer:SetText (Plater.FormatTimeDecimal (self.RemainingTime))

--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1278,7 +1278,7 @@ end
 	local function AuraIconOnTick_UpdateCooldown (self, deltaTime)
 		local now = GetTime()
 		if (self.lastUpdateCooldown + 0.05) <= now then
-			self.RemainingTime = self.ExpirationTime - now
+			self.RemainingTime = (self.ExpirationTime - now) / self.ModRate
 			if self.RemainingTime > 0 then
 				if self.formatWithDecimals then
 					self.Cooldown.Timer:SetText (Plater.FormatTimeDecimal (self.RemainingTime))


### PR DESCRIPTION
This bug is noticeable on the 10.2 PTR for rogues, as the Underhanded Upper Hand talent seems to work by applying a time mod of 100 to the buffs it pauses when it "pauses" them, so the ModRate changes with buff state.