### PR TITLE
Added missing interrupt members to castBar scripting panel

### DIFF
--- a/Plater_ChangeLog.lua
+++ b/Plater_ChangeLog.lua
@@ -8,6 +8,7 @@ function Plater.GetChangelogTable()
 	if (not Plater.ChangeLogTable) then
 		Plater.ChangeLogTable = {
 
+			{1729585511, "Bug Fix", "Nov 15th, 2024", "Added missing references to castBar.InterruptSourceName and castBar.InterruptSourceGUID in scripting panels.", "Linaori"},
 			{1729585511, "Backend Change", "Nov 14th, 2024", "Changed default values for DBM boss mod support and enabled it by default.", "cont1nuity"},
 			{1729585511, "New Feature", "Nov 14th, 2024", "Added glow options for expiring DBM boss mod icons.", "cont1nuity"},
 			{1729585511, "New Feature", "Nov 7th, 2024", "Added castBar.SpellNameRenamed, which contains either the customized or boss mods spell rename.", "Linaori"},

--- a/Plater_ScriptingPanels.lua
+++ b/Plater_ScriptingPanels.lua
@@ -264,6 +264,8 @@ Plater.NameplateComponents = {
 		"SpellEndTime",
 		"CanInterrupt",
 		"IsInterrupted",
+		"InterruptSourceName",
+		"InterruptSourceGUID",
 	},
 	
 	["castBar - Frames"] = {


### PR DESCRIPTION
Wanted to customize the layout of the interrupt message and found these members in the code, just not in the scripting panels