### PR TITLE
Updated the wording of the priority tooltip

### DIFF
--- a/Plater_ScriptingPanels.lua
+++ b/Plater_ScriptingPanels.lua
@@ -1562,7 +1562,7 @@ end
 		local script_prio_label = DF:CreateLabel (parent, "Priority:", DF:GetTemplate ("font", "ORANGE_FONT_TEMPLATE"))
 		local script_prio_entry = DF:CreateSlider (parent, 191, 20, 1, 99, 1, 99, false, "ScriptPrioritySlider", _, _, options_slider_template, _)
 		script_prio_entry:SetPoint ("topleft", script_prio_label, "bottomleft", 0, -2)
-		script_prio_entry.tooltip = "Lower number -> higher priority.\nRight Click to Type the Value"
+		script_prio_entry.tooltip = "Higher priority runs before lower priority.\nRight Click to Type the Value"
 		mainFrame.ScriptPrioSlideEntry = script_prio_entry
 
 		--options button

--- a/Plater_ScriptingPanels.lua
+++ b/Plater_ScriptingPanels.lua
@@ -1562,7 +1562,7 @@ end
 		local script_prio_label = DF:CreateLabel (parent, "Priority:", DF:GetTemplate ("font", "ORANGE_FONT_TEMPLATE"))
 		local script_prio_entry = DF:CreateSlider (parent, 191, 20, 1, 99, 1, 99, false, "ScriptPrioritySlider", _, _, options_slider_template, _)
 		script_prio_entry:SetPoint ("topleft", script_prio_label, "bottomleft", 0, -2)
-		script_prio_entry.tooltip = "Higher priority runs before lower priority.\nRight Click to Type the Value"
+		script_prio_entry.tooltip = "Lower number -> higher priority.\nHigher priority runs before lower priority.\nRight Click to Type the Value"
 		mainFrame.ScriptPrioSlideEntry = script_prio_entry
 
 		--options button
@@ -4819,3 +4819,4 @@ function Plater.CreateScriptingPanel()
 end
 
 --endd ends
+


### PR DESCRIPTION
Confirmed that this is indeed the order of execution, but based on the original tooltip it was rather unclear to me how it behaved.

![Wow_o6iiwelkl3](https://github.com/user-attachments/assets/cd9ce291-51fc-47d6-86a3-5c7c58ca4447)
