### PR TITLE
Improve/fix the cast bar script previews

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -12126,7 +12126,7 @@ end
 			table.wipe(SCRIPT_AURA_TRIGGER_CACHE)
 			table.wipe(SCRIPT_CASTBAR_TRIGGER_CACHE)
 			table.wipe(SCRIPT_UNIT_TRIGGER_CACHE)
-			table.wipe(platerInternal.Scripts.DefaultCastScripts)
+			table.wipe(platerInternal.Scripts.CurrentCastScripts)
 			Plater.CompileAllScripts (scriptType, noHotReload)
 			
 			Plater.EndLogPerformanceCore("Plater-Core", "Mod/Script", "WipeAndRecompileAllScripts - script")
@@ -12663,13 +12663,10 @@ end
 			end
 		end
 
-		--add castbar scripts to the default list for previews
+		--add castbar scripts to the current list for previews
 		if (scriptObject.ScriptType == 2) then
-			local defaultScripts = platerInternal.Scripts.DefaultCastScripts
-			local index = DF.table.find(defaultScripts, scriptObject.Name)
-			if (not index) then
-				table.insert(defaultScripts, scriptObject.Name)
-			end
+			local currentScripts = platerInternal.Scripts.CurrentCastScripts
+			DF.table.addunique(currentScripts, scriptObject.Name)
 		end
 		
 		--trigger container is the table with spellIds for auras and/or spellcast

--- a/Plater.lua
+++ b/Plater.lua
@@ -80,6 +80,9 @@ local IS_WOW_PROJECT_CLASSIC_WRATH = IS_WOW_PROJECT_NOT_MAINLINE and ClassicExpa
 --local IS_WOW_PROJECT_CLASSIC_CATACLYSM = IS_WOW_PROJECT_NOT_MAINLINE and ClassicExpansionAtLeast and LE_EXPANSION_CATACLYSM and ClassicExpansionAtLeast(LE_EXPANSION_CATACLYSM)
 local IS_WOW_PROJECT_CLASSIC_MOP = IS_WOW_PROJECT_NOT_MAINLINE and ClassicExpansionAtLeast and LE_EXPANSION_MISTS_OF_PANDARIA and ClassicExpansionAtLeast(LE_EXPANSION_MISTS_OF_PANDARIA)
 
+--frostbolt
+local CONST_PREVIEW_SPELLID = 116
+
 local PixelUtil = PixelUtil or DFPixelUtil
 
 local parserFunctions --reference needed
@@ -4961,7 +4964,7 @@ function Plater.OnInit() --private --~oninit ~init
 			if plateFrame.unitFrame.PlaterOnScreen then
 				local castBar = plateFrame.unitFrame.castBar
 				local castNoInterrupt = Plater.CastBarTestFrame.castNoInterrupt
-				local spellName, _, spellIcon = GetSpellInfo(116)
+				local spellName, _, spellIcon = GetSpellInfo(CONST_PREVIEW_SPELLID)
 
 				castBar.Text:SetText(spellName)
 				castBar.Icon:SetTexture(spellIcon)
@@ -4975,13 +4978,13 @@ function Plater.OnInit() --private --~oninit ~init
 				castBar.finished = false
 				castBar.value = 0
 				castBar.maxValue = (castTime or 3)
-				castBar.canInterrupt = castNoInterrupt or math.random (1, 2) == 1
+				castBar.canInterrupt = not castNoInterrupt or math.random (1, 2) == 1
 				--castBar.canInterrupt = true
 				--castBar.channeling = true
 				castBar:UpdateCastColor()
 
 				castBar.spellName = 		spellName
-				castBar.spellID = 			116
+				castBar.spellID = 			CONST_PREVIEW_SPELLID
 				castBar.spellTexture = 		spellIcon
 				castBar.spellStartTime = 	GetTime()
 				castBar.spellEndTime = 		GetTime() + (castTime or 3)
@@ -12123,6 +12126,7 @@ end
 			table.wipe(SCRIPT_AURA_TRIGGER_CACHE)
 			table.wipe(SCRIPT_CASTBAR_TRIGGER_CACHE)
 			table.wipe(SCRIPT_UNIT_TRIGGER_CACHE)
+			table.wipe(platerInternal.Scripts.DefaultCastScripts)
 			Plater.CompileAllScripts (scriptType, noHotReload)
 			
 			Plater.EndLogPerformanceCore("Plater-Core", "Mod/Script", "WipeAndRecompileAllScripts - script")
@@ -12656,6 +12660,15 @@ end
 
 				--extract the function
 				scriptFunctions[scriptType] = compiledScript()
+			end
+		end
+
+		--add castbar scripts to the default list for previews
+		if (scriptObject.ScriptType == 2) then
+			local defaultScripts = platerInternal.Scripts.DefaultCastScripts
+			local index = DF.table.find(defaultScripts, scriptObject.Name)
+			if (not index) then
+				table.insert(defaultScripts, scriptObject.Name)
 			end
 		end
 		

--- a/Plater_CastColorPanels.lua
+++ b/Plater_CastColorPanels.lua
@@ -713,15 +713,15 @@ function Plater.CreateCastColorOptionsFrame(castColorFrame)
     --receives a spellId and verify if this spellId is a trigger of any script
     local hasScriptWithPreviewSpellId = function(spellId)
         local previewSpellId = spellId or CONST_PREVIEW_SPELLID
-        local defaultCastScripts = platerInternal.Scripts.DefaultCastScripts
+        local currentCastScripts = platerInternal.Scripts.CurrentCastScripts
         local GetScriptObjectByName = platerInternal.Scripts.GetScriptObjectByName
         local find = DF.table.find
 
-        for i = 1, #defaultCastScripts do
-            local scriptName = defaultCastScripts[i]
+        for i = 1, #currentCastScripts do
+            local scriptName = currentCastScripts[i]
             ---@type scriptdata
             local scriptObject = GetScriptObjectByName(scriptName)
-            if (scriptObject) then
+            if (scriptObject and scriptObject.Enabled) then
                 local index = find(scriptObject.SpellIds, previewSpellId)
                 if (index) then
                     return true
@@ -730,17 +730,30 @@ function Plater.CreateCastColorOptionsFrame(castColorFrame)
         end
     end
 
+    --we want to have all the default scripts show up last in the list, so temporarily put any default script into a separate table
+    local currentCastScripts = platerInternal.Scripts.CurrentCastScripts
+    local scriptsDefault = {}
     local scriptsToShow = {}
-    for i = 1, #platerInternal.Scripts.DefaultCastScripts do
-        local scriptName = platerInternal.Scripts.DefaultCastScripts[i]
+
+    for i = 1, #platerInternal.Scripts.CurrentCastScripts do
+        local scriptName = platerInternal.Scripts.CurrentCastScripts[i]
 
         local scriptObject = platerInternal.Scripts.GetScriptObjectByName(scriptName)
-        if (scriptObject) then
-            scriptsToShow[#scriptsToShow + 1] = scriptName
+        if (scriptObject and scriptObject.Enabled) then
+            --platerInternal.Scripts.DefaultCastScripts might not contain all the scripts tagged with [P] or [Plater], so just search for those strings directly
+            local lowerName = scriptName:lower()
+            if (string.find(lowerName, "%[p%]") or string.find(lowerName, "%[plater%]")) then
+                table.insert(scriptsDefault, scriptName)
+            else
+                table.insert(scriptsToShow, scriptName)
+            end
         end
     end
 
+    --sort both lists, and then append the default scripts to the full preview list
     table.sort(scriptsToShow)
+    table.sort(scriptsDefault)
+    DF.table.append(scriptsToShow, scriptsDefault)
 
     local castBarPreviewTexture = "" --[[Interface\AddOns\Plater\Images\cast_bar_scripts_preview]]
     local eachCastBarButtonHeight = PlaterOptionsPanelContainerCastColorManagementColorFrameScriptPreviewPanel:GetHeight() / math.max(#scriptsToShow, 12)
@@ -852,8 +865,8 @@ function Plater.CreateCastColorOptionsFrame(castColorFrame)
 
     function castColorFrame.SelectScriptForSpellId(spellId)
         local foundScriptWithThisSpellId = false
-        for i = 1, #platerInternal.Scripts.DefaultCastScripts do
-            local scriptName = platerInternal.Scripts.DefaultCastScripts[i]
+        for i = 1, #platerInternal.Scripts.CurrentCastScripts do
+            local scriptName = platerInternal.Scripts.CurrentCastScripts[i]
             local scriptObject = platerInternal.Scripts.GetScriptObjectByName(scriptName)
             if (scriptObject) then
                 local hasTrigger = platerInternal.Scripts.DoesScriptHasTrigger(scriptObject, spellId)
@@ -933,8 +946,8 @@ function Plater.CreateCastColorOptionsFrame(castColorFrame)
     end
 
     function spFrame.RemovePreviewTriggerFromAllScripts()
-        for i = 1, #platerInternal.Scripts.DefaultCastScripts do
-            local scriptName = platerInternal.Scripts.DefaultCastScripts[i]
+        for i = 1, #platerInternal.Scripts.CurrentCastScripts do
+            local scriptName = platerInternal.Scripts.CurrentCastScripts[i]
             local scriptObject = platerInternal.Scripts.GetScriptObjectByName(scriptName)
             if (scriptObject) then
                 platerInternal.Scripts.RemoveSpellFromScriptTriggers(scriptObject, CONST_PREVIEW_SPELLID)

--- a/Plater_CastColorPanels.lua
+++ b/Plater_CastColorPanels.lua
@@ -730,9 +730,6 @@ function Plater.CreateCastColorOptionsFrame(castColorFrame)
         end
     end
 
-    local castBarPreviewTexture = "" --[[Interface\AddOns\Plater\Images\cast_bar_scripts_preview]]
-    local eachCastBarButtonHeight = PlaterOptionsPanelContainerCastColorManagementColorFrameScriptPreviewPanel:GetHeight() / #platerInternal.Scripts.DefaultCastScripts
-
     local scriptsToShow = {}
     for i = 1, #platerInternal.Scripts.DefaultCastScripts do
         local scriptName = platerInternal.Scripts.DefaultCastScripts[i]
@@ -742,6 +739,11 @@ function Plater.CreateCastColorOptionsFrame(castColorFrame)
             scriptsToShow[#scriptsToShow + 1] = scriptName
         end
     end
+
+    table.sort(scriptsToShow)
+
+    local castBarPreviewTexture = "" --[[Interface\AddOns\Plater\Images\cast_bar_scripts_preview]]
+    local eachCastBarButtonHeight = PlaterOptionsPanelContainerCastColorManagementColorFrameScriptPreviewPanel:GetHeight() / math.max(#scriptsToShow, 12)
 
     for i = 1, #scriptsToShow do
         local scriptName = scriptsToShow[i]

--- a/Plater_CastColorPanels.lua
+++ b/Plater_CastColorPanels.lua
@@ -732,17 +732,20 @@ function Plater.CreateCastColorOptionsFrame(castColorFrame)
 
     --we want to have all the default scripts show up last in the list, so temporarily put any default script into a separate table
     local currentCastScripts = platerInternal.Scripts.CurrentCastScripts
+    local defaultCastScripts = platerInternal.Scripts.DefaultCastScripts
+    local defaultCastScriptsNames = {}
     local scriptsDefault = {}
     local scriptsToShow = {}
 
-    for i = 1, #platerInternal.Scripts.CurrentCastScripts do
-        local scriptName = platerInternal.Scripts.CurrentCastScripts[i]
+    for i = 1, #defaultCastScripts do
+        defaultCastScriptsNames[defaultCastScripts[i]] = true
+    end
 
+    for i = 1, #currentCastScripts do
+        local scriptName = currentCastScripts[i]
         local scriptObject = platerInternal.Scripts.GetScriptObjectByName(scriptName)
         if (scriptObject and scriptObject.Enabled) then
-            --platerInternal.Scripts.DefaultCastScripts might not contain all the scripts tagged with [P] or [Plater], so just search for those strings directly
-            local lowerName = scriptName:lower()
-            if (string.find(lowerName, "%[p%]") or string.find(lowerName, "%[plater%]")) then
+            if (defaultCastScriptsNames[scriptName]) then
                 table.insert(scriptsDefault, scriptName)
             else
                 table.insert(scriptsToShow, scriptName)

--- a/Plater_ScriptLibrary.lua
+++ b/Plater_ScriptLibrary.lua
@@ -26,6 +26,8 @@ platerInternal.Scripts.DefaultCastScripts = {
 	"Cast - Very Important [Plater]",
 }
 
+platerInternal.Scripts.CurrentCastScripts = {}
+
 do
 	PlaterScriptLibrary = {}
 


### PR DESCRIPTION
- Define CONST_PREVIEW_SPELLID in Plater.lua as well, and use this in all cases.
- Allow the castNoInterrupt arg to actually let non-interruptible spells to be previewed.
- Wipe DefaultCastScripts when recompiling all scripts.
- Add all spell casting (2) scripts to DefaultCastScripts during compilation.
- Sort the list of scripts to show in the preview window.
- Use the number of preview scripts with a reasonable minimum of 12 for the preview cast height.