### PR TITLE
fix CheckAuras function, unitFrame variable is not in scope

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -10660,7 +10660,7 @@ end
 			Plater.AlignAuraFrames (buffFrame2)
 			--buffFrame2:SetAlpha (DB_AURA_ALPHA)
 		end
-		Plater.RunScriptTriggersForAuraIcons (unitFrame)
+		Plater.RunScriptTriggersForAuraIcons (self)
 	end
 	
 	--return the health bar and the unitname text


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fc41fef8-1f01-44f7-94d4-356dad8e56bd)
At the momnet funtion CheckAuras is unusable due to undefined variable unitFrame in local scope