### PR TITLE
Add global GetSpecialization shims for Classic clients

### DIFF
--- a/Plater.lua
+++ b/Plater.lua
@@ -80,6 +80,14 @@ end
 local GetSpecialization = C_SpecializationInfo and C_SpecializationInfo.GetSpecialization or GetSpecialization
 local GetSpecializationInfo = C_SpecializationInfo and C_SpecializationInfo.GetSpecializationInfo or GetSpecializationInfo
 
+--provide global shims for classic clients where these APIs don't exist, so third-party scripts don't error
+if not _G.GetSpecialization then
+	_G.GetSpecialization = function() return nil end
+end
+if not _G.GetSpecializationInfo then
+	_G.GetSpecializationInfo = function() return nil end
+end
+
 local IS_WOW_PROJECT_MAINLINE = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 local IS_WOW_PROJECT_NOT_MAINLINE = WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE
 local IS_WOW_PROJECT_CLASSIC_ERA = WOW_PROJECT_ID == WOW_PROJECT_CLASSIC


### PR DESCRIPTION
## Summary
- On Classic/TBC clients, neither `C_SpecializationInfo` nor the global `GetSpecialization`/`GetSpecializationInfo` APIs exist
- Plater's own code guards these calls with `IS_WOW_PROJECT_MAINLINE` checks, but third-party mod scripts (e.g. "Advanced Execute Range [Fixed]" from wago.io) call the global `GetSpecialization()` directly
- This causes `attempt to call global 'GetSpecialization' (a nil value)` errors on Player Logon
- Adds safe no-op global shims (returning `nil`) when these APIs don't exist, preventing third-party script crashes on Classic clients

## Error reproduced
```
[string "Initialization for Advanced Execute Range [..."]:11: attempt to call global 'GetSpecialization' (a nil value)
```
Triggered by the "Advanced Execute Range [Fixed]" wago.io script on a TBC/Anniversary Classic client (Plater-v638-TBC).

## Test plan
- [ ] Verify no errors on Classic/TBC/Anniversary clients when loading mods that call `GetSpecialization()`
- [ ] Verify retail behavior is unchanged (global already exists, shim is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)