### PR TITLE
Fix WoW 12.1 aura filters and restore legacy presentation

### DIFF
--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1805,7 +1805,9 @@ function reSkinAuraButtons(auraButtons, options)
 		auraButton:SetSizes()
 		auraButton:SetBorderSize(borderThickness)
 		auraButton:SetScale(1)
-		Plater.UpdateIconAspecRatio(auraButton)
+		-- CustomAuraButton:GetSize() returns secret dimensions after Blizzard has
+		-- restricted the frame. The icon crop is initialized while the button is
+		-- created; do not read its protected size again during a later reskin.
 
 		if borderThickness > 0 then
 			auraButton.Border:Show()

--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1062,6 +1062,22 @@ local function getAuraFilters(frameName, actorType, force)
 				})
 			end
 
+			if DB_AURA_SHOW_MAGIC and not DB_SHOW_MAGIC_IN_EXTRA_ICONS and not canAssist then
+				local candidate = DF.table.copy({}, allCandidates.mainFilter)
+				candidate.includeSpellIDs = nil
+				candidate.excludeDispelTypes = nil
+				candidate.includeDispelTypes = {Magic = true}
+				table.insert(filters, {
+					filterString = "HELPFUL" .. (DB_SHOW_PURGE_IN_EXTRA_ICONS and "|!RAID_PLAYER_DISPELLABLE" or "") .. (Plater.db.profile.extra_icon_show_defensive and "|!BIG_DEFENSIVE|!EXTERNAL_DEFENSIVE" or ""),
+					candidateFilters = candidate,
+				})
+
+				-- candidate filters are cached by frame name, do not mutate the cached table
+				local remainingCandidate = DF.table.copy({}, allCandidates.mainFilter)
+				remainingCandidate.excludeDispelTypes = {Magic = true}
+				allCandidates.mainFilter = remainingCandidate
+			end
+
 			if Plater.db.profile.aura_show_defensive_cd and not Plater.db.profile.extra_icon_show_defensive  then
 				if isPlayer then
 					table.insert(pFilters, "BIG_DEFENSIVE")
@@ -1096,7 +1112,7 @@ local function getAuraFilters(frameName, actorType, force)
 				pFilters = {}
 			end
 
-			if DB_AURA_SHOW_BUFFS_AS_BLIZZARD and not DB_AURA_SHOW_BUFFENEMYNPC and not canAssist and not isPlayer then
+			if DB_AURA_SHOW_BUFFS_AS_BLIZZARD and not DB_AURA_SHOW_BUFFENEMYNPC and not canAssist then
 				local candidate = DF.table.copy({}, allCandidates.mainFilter)
 				candidate.includeSpellIDs = nil
 				--candidate.nameplateShowPersonal = true

--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1287,6 +1287,9 @@ local function createLegacyAuraBorder(auraButton, frameName)
 	-- the legacy aura frame. Secure dispel colors live in a separate overlay so
 	-- disabling type colors can leave the normal border untouched.
 	local border = DF:CreateFullBorder(nil, auraButton)
+	for _, texture in ipairs(border.Textures) do
+		texture:SetDrawLayer("overlay", 7)
+	end
 	border.frameName = frameName
 	border.TypeOverlay = CreateFrame("Frame", nil, border)
 	border.TypeOverlay:SetAllPoints()

--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1215,6 +1215,198 @@ local function getAuraFilters(frameName, actorType, force)
 	return filters
 end
 
+local function makeUniformAuraColorMap(color, enrageColor)
+	enrageColor = enrageColor or color
+	return {
+		["None"] = CreateColor(unpack(color)),
+		["Magic"] = CreateColor(unpack(color)),
+		["Curse"] = CreateColor(unpack(color)),
+		["Disease"] = CreateColor(unpack(color)),
+		["Poison"] = CreateColor(unpack(color)),
+		["Bleed"] = CreateColor(unpack(color)),
+		["Enrage"] = CreateColor(unpack(enrageColor)),
+	}
+end
+
+local function makeConfiguredAuraColorMap(colors)
+	return {
+		["None"] = CreateColor(unpack(colors.none)),
+		["Magic"] = CreateColor(unpack(colors.magic)),
+		["Curse"] = CreateColor(unpack(colors.curse)),
+		["Disease"] = CreateColor(unpack(colors.disease)),
+		["Poison"] = CreateColor(unpack(colors.poison)),
+		["Bleed"] = CreateColor(unpack(colors.bleed)),
+		["Enrage"] = CreateColor(unpack(colors.enrage)),
+	}
+end
+
+local function makeAuraBorderOptions(showHelpful, showHarmful, colorMap, stealableFilter)
+	return {
+		showIcon = false,
+		showWhenHarmful = showHarmful,
+		showWhenHelpful = showHelpful,
+		showWithoutDispelType = true,
+		stealableFilter = stealableFilter,
+		style = Enum.CustomAuraButtonDispelTypeTextureStyle.PreserveAsset,
+		customDispelColorMap = colorMap,
+	}
+end
+
+local function getLegacyAuraBorderPresentations(frameName)
+	local profile = Plater.db.profile
+	local presentations = {}
+
+	if frameName == "ExtraIconFrame" then
+		local colors = profile.extra_icon_dispel_type_colors
+		local colorMap = profile.extra_icon_aura_border_colors_by_type and makeConfiguredAuraColorMap(colors) or makeUniformAuraColorMap(colors.default)
+		table.insert(presentations, {
+			layer = "Generic",
+			defaultColor = colors.default,
+			options = makeAuraBorderOptions(true, true, colorMap),
+		})
+		return presentations
+	end
+
+	local colors = profile.aura_border_colors
+	if profile.aura_border_colors_by_type then
+		table.insert(presentations, {
+			layer = "Generic",
+			defaultColor = colors.default,
+			options = makeAuraBorderOptions(true, true, makeConfiguredAuraColorMap(colors)),
+		})
+		return presentations
+	end
+
+	local mayShowHelpful = not profile.buffs_on_aura2 or frameName == "Secondary"
+	local mayShowHarmful = not profile.buffs_on_aura2 or frameName == "Main"
+	if mayShowHelpful then
+		table.insert(presentations, {
+			layer = "Helpful",
+			defaultColor = colors.is_buff,
+			options = makeAuraBorderOptions(true, false, makeUniformAuraColorMap(colors.is_buff, colors.enrage)),
+		})
+	end
+	if mayShowHarmful then
+		table.insert(presentations, {
+			layer = "Harmful",
+			defaultColor = colors.is_debuff,
+			options = makeAuraBorderOptions(false, true, makeUniformAuraColorMap(colors.is_debuff)),
+		})
+	end
+	if mayShowHelpful then
+		table.insert(presentations, {
+			layer = "Stealable",
+			defaultColor = colors.steal_or_purge,
+			options = makeAuraBorderOptions(true, false, makeUniformAuraColorMap(colors.steal_or_purge), Enum.CustomAuraButtonDispelTypeStealableFilter.Stealable),
+		})
+	end
+
+	return presentations
+end
+
+local function createLegacyAuraBorder(auraButton, frameName)
+	local border = CreateFrame("Frame", nil, auraButton)
+	border:SetAllPoints()
+	border:SetIgnoreParentScale(true)
+	border:SetFrameLevel(auraButton:GetFrameLevel())
+	border.frameName = frameName
+	border.Layers = {}
+	border.Textures = {}
+
+	function border:AddLayer(layerName)
+		if self.Layers[layerName] then
+			return self.Layers[layerName]
+		end
+
+		local layer = DF:CreateFullBorder(nil, border)
+		-- the wrapper owns the old ignore-parent-scale behavior and animation
+		layer:SetIgnoreParentScale(false)
+		self.Layers[layerName] = layer
+		for _, texture in ipairs(layer.Textures) do
+			texture:SetDrawLayer("overlay", 7)
+			table.insert(self.Textures, texture)
+		end
+		if self.borderSize then
+			local minimumPixels = self.frameName == "ExtraIconFrame" and 1 or 0
+			layer:SetBorderSizes(self.borderSize, minimumPixels, self.borderSize, 0)
+			layer:UpdateSizes()
+		end
+		return layer
+	end
+
+	function border:SetVertexColor(r, g, b, a)
+		for _, texture in ipairs(self.Textures) do
+			texture:SetVertexColor(r, g, b, a)
+		end
+	end
+
+	function border:SetBorderSize(size)
+		local borderSize = (size or 1) * UIParent:GetEffectiveScale()
+		self.borderSize = borderSize
+		local minimumPixels = self.frameName == "ExtraIconFrame" and 1 or 0
+		for _, layer in pairs(self.Layers) do
+			layer:SetBorderSizes(borderSize, minimumPixels, borderSize, 0)
+			layer:UpdateSizes()
+		end
+	end
+
+	for _, presentation in ipairs(getLegacyAuraBorderPresentations(frameName)) do
+		border:AddLayer(presentation.layer)
+	end
+
+	return border
+end
+
+local function applyLegacyAuraBorderPresentation(auraButton, frameName)
+	local presentations = getLegacyAuraBorderPresentations(frameName)
+	auraButton:ClearDispelTypeTextures()
+
+	for _, layer in pairs(auraButton.Border.Layers) do
+		layer:Hide()
+	end
+
+	for _, presentation in ipairs(presentations) do
+		local layer = auraButton.Border:AddLayer(presentation.layer)
+		layer:Show()
+		for _, texture in ipairs(layer.Textures) do
+			texture:SetVertexColor(unpack(presentation.defaultColor))
+			auraButton:AddDispelTypeTexture(texture, presentation.options)
+		end
+	end
+end
+
+local function createLegacyAuraShowAnimation(auraButton)
+	local function onStop()
+		auraButton:SetScale(1)
+	end
+
+	local animation = {}
+	animation.icon = DF:CreateAnimationHub(auraButton.Icon, nil, onStop)
+	DF:CreateAnimation(animation.icon, "Scale", 1, .05, .7, .7, 1.1, 1.1)
+	DF:CreateAnimation(animation.icon, "Scale", 2, .05, 1.1, 1.1, 1, 1)
+
+	animation.border = DF:CreateAnimationHub(auraButton.Border, nil, onStop)
+	DF:CreateAnimation(animation.border, "Scale", 1, .05, .7, .7, 1.1, 1.1)
+	DF:CreateAnimation(animation.border, "Scale", 2, .05, 1.1, 1.1, 1, 1)
+
+	function animation:Play()
+		self.icon:Play()
+		self.border:Play()
+	end
+	function animation:Stop()
+		self.icon:Stop()
+		self.border:Stop()
+	end
+
+	auraButton.ShowAnimation = animation
+	auraButton:HookScript("OnShow", function(self)
+		self.ShowAnimation:Play()
+	end)
+	auraButton:HookScript("OnHide", function(self)
+		self.ShowAnimation:Stop()
+	end)
+end
+
 --TODO: by container group as well. requires larger rework of the whole current setup. support separate sizes for "own" debuffs/buffs
 local function getAuraFrameLayout(frameName)
 	Plater.StartLogPerformanceCore("Plater-Core", "Update", "getAuraFrameLayout")
@@ -1339,11 +1531,10 @@ local function initAuraFrame(auraButton, frameName, frameKey, auraContainer)
 	-- create stuff
 	local iconOffset = 0
 	auraButton.Icon = auraButton:CreateTexture (nil, "artwork")
-	--PixelUtil.SetPoint (auraButton.Icon, "TOPLEFT", auraButton, "TOPLEFT", -iconOffset, iconOffset)
-	--PixelUtil.SetPoint (auraButton.Icon, "TOPRIGHT", auraButton, "TOPRIGHT", iconOffset, iconOffset)
-	--PixelUtil.SetPoint (auraButton.Icon, "BOTTOMLEFT", auraButton, "BOTTOMLEFT", -iconOffset, -iconOffset)
-	--PixelUtil.SetPoint (auraButton.Icon, "BOTTOMRIGHT", auraButton, "BOTTOMRIGHT", iconOffset, -iconOffset)
-	auraButton.Icon:SetPoint("Center")
+	PixelUtil.SetPoint (auraButton.Icon, "TOPLEFT", auraButton, "TOPLEFT", -iconOffset, iconOffset)
+	PixelUtil.SetPoint (auraButton.Icon, "TOPRIGHT", auraButton, "TOPRIGHT", iconOffset, iconOffset)
+	PixelUtil.SetPoint (auraButton.Icon, "BOTTOMLEFT", auraButton, "BOTTOMLEFT", -iconOffset, -iconOffset)
+	PixelUtil.SetPoint (auraButton.Icon, "BOTTOMRIGHT", auraButton, "BOTTOMRIGHT", iconOffset, -iconOffset)
 	auraButton.Icon:SetTexCoord (.05, .95, .1, .6)
 	auraButton.Icon:SetTexelSnappingBias(0.0)
 	auraButton.Icon:SetSnapToPixelGrid(false)
@@ -1351,11 +1542,10 @@ local function initAuraFrame(auraButton, frameName, frameKey, auraContainer)
 	auraButton:SetIcon(auraButton.Icon)
 	
 	auraButton.Cooldown = CreateFrame ("cooldown", "$parentCooldown", auraButton, "CooldownFrameTemplate")
-	--PixelUtil.SetPoint (auraButton.Cooldown, "TOPLEFT", auraButton, "TOPLEFT", -iconOffset, iconOffset)
-	--PixelUtil.SetPoint (auraButton.Cooldown, "TOPRIGHT", auraButton, "TOPRIGHT", iconOffset, iconOffset)
-	--PixelUtil.SetPoint (auraButton.Cooldown, "BOTTOMLEFT", auraButton, "BOTTOMLEFT", -iconOffset, -iconOffset)
-	--PixelUtil.SetPoint (auraButton.Cooldown, "BOTTOMRIGHT", auraButton, "BOTTOMRIGHT", iconOffset, -iconOffset)
-	auraButton.Cooldown:SetPoint("Center")
+	PixelUtil.SetPoint (auraButton.Cooldown, "TOPLEFT", auraButton, "TOPLEFT", -iconOffset, iconOffset)
+	PixelUtil.SetPoint (auraButton.Cooldown, "TOPRIGHT", auraButton, "TOPRIGHT", iconOffset, iconOffset)
+	PixelUtil.SetPoint (auraButton.Cooldown, "BOTTOMLEFT", auraButton, "BOTTOMLEFT", -iconOffset, -iconOffset)
+	PixelUtil.SetPoint (auraButton.Cooldown, "BOTTOMRIGHT", auraButton, "BOTTOMRIGHT", iconOffset, -iconOffset)
 	auraButton.Cooldown:EnableMouse (false)
 	if auraButton.Cooldown.EnableMouseMotion then
 		auraButton.Cooldown:EnableMouseMotion (false)
@@ -1374,7 +1564,7 @@ local function initAuraFrame(auraButton, frameName, frameKey, auraContainer)
 
 	
 	auraButton.CountFrame = CreateFrame ("frame", "$parentCountFrame", auraButton)--, BackdropTemplateMixin and "BackdropTemplate")
-	auraButton.CountFrame:SetPoint("CENTER")
+	auraButton.CountFrame:SetAllPoints()
 	auraButton.CountFrame:EnableMouse (false)
 	if auraButton.CountFrame.EnableMouseMotion then
 		auraButton.CountFrame:EnableMouseMotion (false)
@@ -1473,67 +1663,59 @@ local function initAuraFrame(auraButton, frameName, frameKey, auraContainer)
 		Plater.SetAnchor (timerLabel, profile.aura_timer_text_anchor) --TODO
 	end
 
-	-- switch to proper border, keep compatibility
-	auraButton.Border = auraButton:CreateTexture(nil, "overlay")
-	--auraButton.Border:SetAllPoints()
-	auraButton.Border:SetTexture([[Interface\AddOns\Plater\images\IconBorderWhite]])
-	local band = 8
-	local offset = 0
-	auraButton.Border:SetTextureSliceMargins(band, band, band, band)
-	--auraButton.Border:SetPoint("TOPLEFT",     auraButton.Icon, "TOPLEFT",     -band * offset,  band * offset)
-	--auraButton.Border:SetPoint("BOTTOMRIGHT", auraButton.Icon, "BOTTOMRIGHT",  band * offset, -band * offset)
-	auraButton.Border:SetAllPoints()
+	-- CustomAuraButton owns the secure color binding, while Plater retains the
+	-- legacy four-edge border geometry and profile sizing.
+	auraButton.Border = createLegacyAuraBorder(auraButton, frameName)
+	auraButton.SetBackdropBorderColor = function(self, r, g, b, a)
+		self.Border:SetVertexColor(r, g, b, a)
+	end
+	auraButton.SetBorderSize = function(self, size)
+		self.Border:SetBorderSize(size)
+	end
+	auraButton.SetSizes = function(self)
+		local extraBorderOffset = 0
+		if self.frameName == "Secondary" then
+			extraBorderOffset = Plater.db.profile.aura_border_extraoffset2 or 0
+		elseif self.frameName == "Main" then
+			extraBorderOffset = Plater.db.profile.aura_border_extraoffset or 0
+		end
+
+		local borderOffset = -1 * UIParent:GetEffectiveScale() + extraBorderOffset
+		self.Border:ClearAllPoints()
+		PixelUtil.SetPoint (self.Border, "TOPLEFT", self, "TOPLEFT", -borderOffset, borderOffset)
+		PixelUtil.SetPoint (self.Border, "TOPRIGHT", self, "TOPRIGHT", borderOffset, borderOffset)
+		PixelUtil.SetPoint (self.Border, "BOTTOMLEFT", self, "BOTTOMLEFT", -borderOffset, -borderOffset)
+		PixelUtil.SetPoint (self.Border, "BOTTOMRIGHT", self, "BOTTOMRIGHT", borderOffset, -borderOffset)
+
+		self.Icon:ClearAllPoints()
+		PixelUtil.SetPoint (self.Icon, "TOPLEFT", self, "TOPLEFT", 0, 0)
+		PixelUtil.SetPoint (self.Icon, "TOPRIGHT", self, "TOPRIGHT", 0, 0)
+		PixelUtil.SetPoint (self.Icon, "BOTTOMLEFT", self, "BOTTOMLEFT", 0, 0)
+		PixelUtil.SetPoint (self.Icon, "BOTTOMRIGHT", self, "BOTTOMRIGHT", 0, 0)
+
+		local cooldownOffset = -1 * UIParent:GetEffectiveScale()
+		self.Cooldown:ClearAllPoints()
+		PixelUtil.SetPoint (self.Cooldown, "TOPLEFT", self, "TOPLEFT", -cooldownOffset, cooldownOffset)
+		PixelUtil.SetPoint (self.Cooldown, "TOPRIGHT", self, "TOPRIGHT", cooldownOffset, cooldownOffset)
+		PixelUtil.SetPoint (self.Cooldown, "BOTTOMLEFT", self, "BOTTOMLEFT", -cooldownOffset, -cooldownOffset)
+		PixelUtil.SetPoint (self.Cooldown, "BOTTOMRIGHT", self, "BOTTOMRIGHT", cooldownOffset, -cooldownOffset)
+	end
+
+	auraButton.frameName = frameName
+	auraButton:SetSize(auraWidth, auraHeight)
+	auraButton:SetSizes()
+	auraButton:SetBorderSize(borderThickness)
 	if borderThickness > 0 then
-		auraButton.Border:SetScale(borderThickness / band)
 		auraButton.Border:Show()
 	else
 		auraButton.Border:Hide()
 	end
-	local defaultColor = frameName ~= "ExtraIconFrame" and Plater.db.profile.aura_border_colors.default or Plater.db.profile.extra_icon_dispel_type_colors.default
-    auraButton.Border:SetVertexColor(defaultColor[1], defaultColor[2], defaultColor[3], defaultColor[4])
-
-	if frameName ~= "ExtraIconFrame" and Plater.db.profile.aura_border_colors_by_type or frameName == "ExtraIconFrame" and Plater.db.profile.extra_icon_aura_border_colors_by_type then
-		local borderOptions = {
-			showIcon = false,
-			showWhenHarmful = true,
-			showWhenHelpful = true,
-			showWithoutDispelType = true,
-			style = Enum.CustomAuraButtonDispelTypeTextureStyle.PreserveAsset,
-			customDispelColorMap = frameName ~= "ExtraIconFrame" and {
-				["None"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.none)),
-				["Magic"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.magic)),
-				["Curse"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.curse)),
-				["Disease"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.disease)),
-				["Poison"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.poison)),
-				["Bleed"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.bleed)),
-				["Enrage"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.enrage)),
-			} or {
-				["None"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.none)),
-				["Magic"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.magic)),
-				["Curse"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.curse)),
-				["Disease"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.disease)),
-				["Poison"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.poison)),
-				["Bleed"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.bleed)),
-				["Enrage"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.enrage)),
-			}
-		}
-		--C_AuraContainerUtil.ProcessCustomAuraButtonDispelTypeTextureOptions(borderOptions)
-		auraButton:SetAuraBorder(auraButton.Border, borderOptions)
-	end
-
-
-	--PixelUtil.SetSize(auraButton.Border, auraWidth, auraHeight)
-	--PixelUtil.SetSize(auraButton, auraWidth, auraHeight)
-	auraButton:SetSize(auraWidth, auraHeight)
-	auraButton.Border:SetSize(auraWidth, auraHeight)
-	auraButton.Icon:SetSize(auraWidth, auraHeight)
-	auraButton.Cooldown:SetSize(auraWidth, auraHeight)
-	auraButton.CountFrame:SetSize(auraWidth, auraHeight)
+	applyLegacyAuraBorderPresentation(auraButton, frameName)
 	auraButton:SetScale(1)
+	createLegacyAuraShowAnimation(auraButton)
 
 	Plater.UpdateIconAspecRatio (auraButton)
 
-	auraButton.frameName = frameName
 	auraButton.frameKey = frameKey
 	auraButton.auraContainer = auraContainer
 
@@ -1663,31 +1845,18 @@ function reSkinAuraButtons(auraButtons, options)
 			Plater.SetAnchor (timerLabel, profile.aura_timer_text_anchor) --TODO
 		end
 
-		--PixelUtil.SetSize(auraButton.Border, auraWidth, auraHeight)
-		--PixelUtil.SetSize(auraButton, auraWidth, auraHeight)
 		auraButton:SetSize(auraWidth, auraHeight)
-		auraButton.Border:SetSize(auraWidth, auraHeight)
-		auraButton.Icon:SetSize(auraWidth, auraHeight)
-		auraButton.Cooldown:SetSize(auraWidth, auraHeight)
-		auraButton.CountFrame:SetSize(auraWidth, auraHeight)
+		auraButton:SetSizes()
+		auraButton:SetBorderSize(borderThickness)
 		auraButton:SetScale(1)
 
-		local band = 8
 		if borderThickness > 0 then
-			auraButton.Border:SetScale(borderThickness / band)
 			auraButton.Border:Show()
 		else
 			auraButton.Border:Hide()
 		end
 
-		local defaultColor = frameName ~= "ExtraIconFrame" and Plater.db.profile.aura_border_colors.default or Plater.db.profile.extra_icon_dispel_type_colors.default
-    	auraButton.Border:SetVertexColor(defaultColor[1], defaultColor[2], defaultColor[3], defaultColor[4])
-
-		if frameName ~= "ExtraIconFrame" and Plater.db.profile.aura_border_colors_by_type or frameName == "ExtraIconFrame" and Plater.db.profile.extra_icon_aura_border_colors_by_type then
-			auraButton:SetAuraBorder(auraButton.Border, options.borderOptions)
-		else
-			auraButton:ClearAuraBorder()
-		end
+		applyLegacyAuraBorderPresentation(auraButton, frameName)
 
 		auraButton.Cooldown:SetEdgeTexture (profile.aura_cooldown_edge_texture)
 		auraButton.Cooldown:SetReverse (profile.aura_cooldown_reverse)
@@ -1755,31 +1924,9 @@ local function getAuraBorderOptions(frameName)
 		Plater.EndLogPerformanceCore("Plater-Core", "Update", "getAuraBorderOptions")
 		return cachedAuraBorderOptions
 	end
-	local borderOptions = {
-		showIcon = false,
-		showWhenHarmful = true,
-		showWhenHelpful = true,
-		showWithoutDispelType = true,
-		style = Enum.CustomAuraButtonDispelTypeTextureStyle.PreserveAsset,
-		customDispelColorMap = frameName ~= "ExtraIconFrame" and {
-			["None"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.none)),
-			["Magic"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.magic)),
-			["Curse"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.curse)),
-			["Disease"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.disease)),
-			["Poison"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.poison)),
-			["Bleed"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.bleed)),
-			["Enrage"] = CreateColor(unpack(Plater.db.profile.aura_border_colors.enrage)),
-		} or {
-			["None"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.none)),
-			["Magic"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.magic)),
-			["Curse"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.curse)),
-			["Disease"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.disease)),
-			["Poison"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.poison)),
-			["Bleed"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.bleed)),
-			["Enrage"] = CreateColor(unpack(Plater.db.profile.extra_icon_dispel_type_colors.enrage)),
-		},
-		optionIndex = containerConfigCache.auraBorderOptionIndex,
-	}
+	local presentations = getLegacyAuraBorderPresentations(frameName)
+	local borderOptions = presentations[1] and presentations[1].options or {}
+	borderOptions.optionIndex = containerConfigCache.auraBorderOptionIndex
 
 	containerConfigCache.auraBorderOptions[frameName] = borderOptions
 

--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1230,7 +1230,8 @@ local function getAuraFrameLayout(frameName)
 	local layout = {
 		elementSpacing = profile.aura_padding,
 		lineSpacing = profile.aura_breakline_space,
-		groupSpacing = profile.aura_padding,
+		-- elementSpacing already provides the legacy gap between adjacent groups
+		groupSpacing = 0,
 		groupLineSpacing = profile.aura_breakline_space,
 		--forceNewLine = false,
 		elementWidth = 26,

--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1255,76 +1255,57 @@ end
 local function getLegacyAuraBorderPresentations(frameName)
 	local profile = Plater.db.profile
 	local presentations = {}
+	local colors
+	local usePersistentTypeColors
 
 	if frameName == "ExtraIconFrame" then
-		local colors = profile.extra_icon_dispel_type_colors
-		local colorMap = profile.extra_icon_aura_border_colors_by_type and makeConfiguredAuraColorMap(colors) or makeUniformAuraColorMap(colors.default)
-		table.insert(presentations, {
-			layer = "Generic",
-			defaultColor = colors.default,
-			options = makeAuraBorderOptions(true, true, colorMap),
-		})
-		return presentations
+		colors = profile.extra_icon_dispel_type_colors
+		usePersistentTypeColors = profile.extra_icon_aura_border_colors_by_type
+	else
+		colors = profile.aura_border_colors
+		usePersistentTypeColors = profile.aura_border_colors_by_type
 	end
 
-	local colors = profile.aura_border_colors
-	if profile.aura_border_colors_by_type then
-		table.insert(presentations, {
-			layer = "Generic",
-			defaultColor = colors.default,
-			options = makeAuraBorderOptions(true, true, makeConfiguredAuraColorMap(colors)),
-		})
-		return presentations
-	end
-
-	local mayShowHelpful = not profile.buffs_on_aura2 or frameName == "Secondary"
-	local mayShowHarmful = not profile.buffs_on_aura2 or frameName == "Main"
-	if mayShowHelpful then
-		table.insert(presentations, {
-			layer = "Helpful",
-			defaultColor = colors.is_buff,
-			options = makeAuraBorderOptions(true, false, makeUniformAuraColorMap(colors.is_buff, colors.enrage)),
-		})
-	end
-	if mayShowHarmful then
-		table.insert(presentations, {
-			layer = "Harmful",
-			defaultColor = colors.is_debuff,
-			options = makeAuraBorderOptions(false, true, makeUniformAuraColorMap(colors.is_debuff)),
-		})
-	end
+	local mayShowHelpful = frameName == "ExtraIconFrame" or not profile.buffs_on_aura2 or frameName == "Secondary"
+	local mayShowHarmful = frameName == "ExtraIconFrame" or not profile.buffs_on_aura2 or frameName == "Main"
+	table.insert(presentations, {
+		layer = "DispelType",
+		options = makeAuraBorderOptions(mayShowHelpful, mayShowHarmful, makeConfiguredAuraColorMap(colors)),
+	})
 	if mayShowHelpful then
 		table.insert(presentations, {
 			layer = "Stealable",
-			defaultColor = colors.steal_or_purge,
-			options = makeAuraBorderOptions(true, false, makeUniformAuraColorMap(colors.steal_or_purge), Enum.CustomAuraButtonDispelTypeStealableFilter.Stealable),
+			options = makeAuraBorderOptions(true, false, makeUniformAuraColorMap(frameName == "ExtraIconFrame" and colors.magic or colors.steal_or_purge), Enum.CustomAuraButtonDispelTypeStealableFilter.Stealable),
 		})
 	end
 
-	return presentations
+	return presentations, colors.default, usePersistentTypeColors
 end
 
 local function createLegacyAuraBorder(auraButton, frameName)
-	local border = CreateFrame("Frame", nil, auraButton)
-	border:SetAllPoints()
-	border:SetIgnoreParentScale(true)
-	border:SetFrameLevel(auraButton:GetFrameLevel())
+	-- Keep the base border on exactly the same direct DF:CreateFullBorder path as
+	-- the legacy aura frame. Secure dispel colors live in a separate overlay so
+	-- disabling type colors can leave the normal border untouched.
+	local border = DF:CreateFullBorder(nil, auraButton)
 	border.frameName = frameName
-	border.Layers = {}
-	border.Textures = {}
+	border.TypeOverlay = CreateFrame("Frame", nil, border)
+	border.TypeOverlay:SetAllPoints()
+	border.TypeOverlay:SetIgnoreParentScale(false)
+	border.TypeOverlay:SetFrameLevel(border:GetFrameLevel())
+	border.TypeOverlay.Layers = {}
+	border.TypeOverlay.persistent = false
 
-	function border:AddLayer(layerName)
-		if self.Layers[layerName] then
-			return self.Layers[layerName]
+	function border:AddTypeLayer(layerName)
+		if self.TypeOverlay.Layers[layerName] then
+			return self.TypeOverlay.Layers[layerName]
 		end
 
-		local layer = DF:CreateFullBorder(nil, border)
-		-- the wrapper owns the old ignore-parent-scale behavior and animation
+		local layer = DF:CreateFullBorder(nil, self.TypeOverlay)
+		-- Let the overlay follow the legacy border's show animation.
 		layer:SetIgnoreParentScale(false)
-		self.Layers[layerName] = layer
+		self.TypeOverlay.Layers[layerName] = layer
 		for _, texture in ipairs(layer.Textures) do
 			texture:SetDrawLayer("overlay", 7)
-			table.insert(self.Textures, texture)
 		end
 		if self.borderSize then
 			local minimumPixels = self.frameName == "ExtraIconFrame" and 1 or 0
@@ -1334,45 +1315,48 @@ local function createLegacyAuraBorder(auraButton, frameName)
 		return layer
 	end
 
-	function border:SetVertexColor(r, g, b, a)
-		for _, texture in ipairs(self.Textures) do
-			texture:SetVertexColor(r, g, b, a)
-		end
-	end
-
 	function border:SetBorderSize(size)
 		local borderSize = (size or 1) * UIParent:GetEffectiveScale()
 		self.borderSize = borderSize
 		local minimumPixels = self.frameName == "ExtraIconFrame" and 1 or 0
-		for _, layer in pairs(self.Layers) do
+		self:SetBorderSizes(borderSize, minimumPixels, borderSize, 0)
+		self:UpdateSizes()
+		for _, layer in pairs(self.TypeOverlay.Layers) do
 			layer:SetBorderSizes(borderSize, minimumPixels, borderSize, 0)
 			layer:UpdateSizes()
 		end
 	end
 
+	function border:SetTypeOverlayPersistent(persistent)
+		self.TypeOverlay.persistent = persistent
+		self.TypeOverlay:SetAlpha(persistent and 1 or 0)
+	end
+
 	for _, presentation in ipairs(getLegacyAuraBorderPresentations(frameName)) do
-		border:AddLayer(presentation.layer)
+		border:AddTypeLayer(presentation.layer)
 	end
 
 	return border
 end
 
 local function applyLegacyAuraBorderPresentation(auraButton, frameName)
-	local presentations = getLegacyAuraBorderPresentations(frameName)
+	local presentations, defaultColor, usePersistentTypeColors = getLegacyAuraBorderPresentations(frameName)
 	auraButton:ClearDispelTypeTextures()
+	auraButton.Border:SetVertexColor(unpack(defaultColor))
 
-	for _, layer in pairs(auraButton.Border.Layers) do
+	for _, layer in pairs(auraButton.Border.TypeOverlay.Layers) do
 		layer:Hide()
 	end
 
 	for _, presentation in ipairs(presentations) do
-		local layer = auraButton.Border:AddLayer(presentation.layer)
+		local layer = auraButton.Border:AddTypeLayer(presentation.layer)
 		layer:Show()
 		for _, texture in ipairs(layer.Textures) do
-			texture:SetVertexColor(unpack(presentation.defaultColor))
 			auraButton:AddDispelTypeTexture(texture, presentation.options)
 		end
 	end
+
+	auraButton.Border:SetTypeOverlayPersistent(usePersistentTypeColors)
 end
 
 local function createLegacyAuraShowAnimation(auraButton)
@@ -1389,13 +1373,24 @@ local function createLegacyAuraShowAnimation(auraButton)
 	DF:CreateAnimation(animation.border, "Scale", 1, .05, .7, .7, 1.1, 1.1)
 	DF:CreateAnimation(animation.border, "Scale", 2, .05, 1.1, 1.1, 1, 1)
 
+	local typeOverlay = auraButton.Border.TypeOverlay
+	animation.typeFlash = DF:CreateAnimationHub(typeOverlay, nil, function()
+		typeOverlay:SetAlpha(typeOverlay.persistent and 1 or 0)
+	end)
+	DF:CreateAnimation(animation.typeFlash, "Alpha", 1, .05, 0, 1)
+	DF:CreateAnimation(animation.typeFlash, "Alpha", 2, .05, 1, 0)
+
 	function animation:Play()
 		self.icon:Play()
 		self.border:Play()
+		if not typeOverlay.persistent then
+			self.typeFlash:Play()
+		end
 	end
 	function animation:Stop()
 		self.icon:Stop()
 		self.border:Stop()
+		self.typeFlash:Stop()
 	end
 
 	auraButton.ShowAnimation = animation
@@ -1702,7 +1697,9 @@ local function initAuraFrame(auraButton, frameName, frameKey, auraContainer)
 	end
 
 	auraButton.frameName = frameName
-	auraButton:SetSize(auraWidth, auraHeight)
+	-- Match the legacy aura path's pixel-rounded frame dimensions. Raw SetSize
+	-- can land the secure icon on fractional physical pixels at non-1 UI scales.
+	PixelUtil.SetSize(auraButton, auraWidth, auraHeight)
 	auraButton:SetSizes()
 	auraButton:SetBorderSize(borderThickness)
 	if borderThickness > 0 then
@@ -1845,10 +1842,11 @@ function reSkinAuraButtons(auraButtons, options)
 			Plater.SetAnchor (timerLabel, profile.aura_timer_text_anchor) --TODO
 		end
 
-		auraButton:SetSize(auraWidth, auraHeight)
+		PixelUtil.SetSize(auraButton, auraWidth, auraHeight)
 		auraButton:SetSizes()
 		auraButton:SetBorderSize(borderThickness)
 		auraButton:SetScale(1)
+		Plater.UpdateIconAspecRatio(auraButton)
 
 		if borderThickness > 0 then
 			auraButton.Border:Show()

--- a/Plater_Auras.lua
+++ b/Plater_Auras.lua
@@ -1362,49 +1362,6 @@ local function applyLegacyAuraBorderPresentation(auraButton, frameName)
 	auraButton.Border:SetTypeOverlayPersistent(usePersistentTypeColors)
 end
 
-local function createLegacyAuraShowAnimation(auraButton)
-	local function onStop()
-		auraButton:SetScale(1)
-	end
-
-	local animation = {}
-	animation.icon = DF:CreateAnimationHub(auraButton.Icon, nil, onStop)
-	DF:CreateAnimation(animation.icon, "Scale", 1, .05, .7, .7, 1.1, 1.1)
-	DF:CreateAnimation(animation.icon, "Scale", 2, .05, 1.1, 1.1, 1, 1)
-
-	animation.border = DF:CreateAnimationHub(auraButton.Border, nil, onStop)
-	DF:CreateAnimation(animation.border, "Scale", 1, .05, .7, .7, 1.1, 1.1)
-	DF:CreateAnimation(animation.border, "Scale", 2, .05, 1.1, 1.1, 1, 1)
-
-	local typeOverlay = auraButton.Border.TypeOverlay
-	animation.typeFlash = DF:CreateAnimationHub(typeOverlay, nil, function()
-		typeOverlay:SetAlpha(typeOverlay.persistent and 1 or 0)
-	end)
-	DF:CreateAnimation(animation.typeFlash, "Alpha", 1, .05, 0, 1)
-	DF:CreateAnimation(animation.typeFlash, "Alpha", 2, .05, 1, 0)
-
-	function animation:Play()
-		self.icon:Play()
-		self.border:Play()
-		if not typeOverlay.persistent then
-			self.typeFlash:Play()
-		end
-	end
-	function animation:Stop()
-		self.icon:Stop()
-		self.border:Stop()
-		self.typeFlash:Stop()
-	end
-
-	auraButton.ShowAnimation = animation
-	auraButton:HookScript("OnShow", function(self)
-		self.ShowAnimation:Play()
-	end)
-	auraButton:HookScript("OnHide", function(self)
-		self.ShowAnimation:Stop()
-	end)
-end
-
 --TODO: by container group as well. requires larger rework of the whole current setup. support separate sizes for "own" debuffs/buffs
 local function getAuraFrameLayout(frameName)
 	Plater.StartLogPerformanceCore("Plater-Core", "Update", "getAuraFrameLayout")
@@ -1712,7 +1669,6 @@ local function initAuraFrame(auraButton, frameName, frameKey, auraContainer)
 	end
 	applyLegacyAuraBorderPresentation(auraButton, frameName)
 	auraButton:SetScale(1)
-	createLegacyAuraShowAnimation(auraButton)
 
 	Plater.UpdateIconAspecRatio (auraButton)
 

--- a/Plater_OptionsPanel.lua
+++ b/Plater_OptionsPanel.lua
@@ -2162,7 +2162,7 @@ local debuff_options = {
 		end,
 		name = "Show Magic Buffs",
 		desc = "Show auras which are in the magic type category.",
-		hidden = IS_WOW_PROJECT_MIDNIGHT,
+		hidden = false,
 	},
 	
 	{


### PR DESCRIPTION
## Summary

This updates Plater's WoW 12.1 `CustomAuraContainer` path to preserve the filtering and static presentation of the pre-12.1 aura frames without requiring users to change their profiles.

- allow hostile-player buffs through **Show Buffs Blizzard Nameplates Show**
- make **Show Magic Buffs** contribute a secure `includeDispelTypes = { Magic = true }` candidate and exclude Magic from the remaining candidate groups to avoid duplicates
- stop applying `aura_padding` twice at secure aura-group boundaries
- restore the legacy four-edge border geometry
- keep the normal border neutral while **Use type based aura border colors** is disabled, and show Blizzard's securely resolved type color persistently only when the option is enabled
- pixel-round the secure aura-button dimensions and refresh icon texcoords on reskin, matching the legacy icon path

## Regression addressed

After the 12.1 migration, the same saved aura settings could produce a different result from pre-12.1 Plater:

1. the Blizzard-nameplate buff filter was gated by `not isPlayer`, so relevant buffs disappeared from enemy player nameplates in Arena/BG
2. `DB_AURA_SHOW_MAGIC` was hidden and no longer mapped to a secure aura group
3. both `elementSpacing` and `groupSpacing` were set to `aura_padding`; Blizzard's flow layout adds both at a group boundary, widening only those gaps
4. the secure button used a sliced texture rather than the legacy direct four-edge border and raw `SetSize` rather than the legacy pixel-rounded size path
5. the first compatibility revision registered a permanent generic Helpful layer while type coloring was disabled; a live Magic-buff test therefore rendered a thick green border instead of the configured neutral border

Debuff filtering is intentionally left alone.

## Implementation notes

The patch stays on Blizzard's secure display path. It does not inspect protected hostile-aura fields in Lua.

The normal border is a direct `DF:CreateFullBorder` object, as in the legacy renderer. A separate child overlay is registered through `AddDispelTypeTexture`, allowing Blizzard to resolve Magic/Curse/Disease/Poison/etc. securely:

- type colors disabled: neutral configured base border; secure type overlay hidden
- type colors enabled: secure type overlay remains visible

An earlier revision attempted to restore the legacy show animation by attaching `OnShow` and `OnHide` hooks during the aura-button initialization callback. Live testing showed that Blizzard already treats the batched `CustomAuraButton` as restricted there and rejected `HookScript` with `blocked by secret aspects`. Commit `ab868fb` removes the hooks and the related animation code.

Existing profiles and defaults are not migrated or rewritten.

## Validation

- [x] hostile-player PvP aura display confirmed in-game by the reporter after the filter change
- [x] live test identified and reproduced the permanent green Helpful-border regression
- [x] live test identified the forbidden `OnShow`/`OnHide` hook regression; the hooks have been removed
- [x] `luaparse` syntax check for `Plater_Auras.lua`
- [x] whitespace/diff checks
- [x] checked the secure texture declarations against the current Blizzard 12.1 UI source
- [ ] live retest after removing all secure aura-button script hooks
- [ ] live retest of neutral/type-overlay behavior and pixel-rounded icon geometry
- [ ] live Arena/BG and M+ regression pass for all filter combinations
- [ ] final taint/error check during combat

The short legacy type-color/show pulse is not restored by this PR because triggering it through aura-button script hooks is not permitted on the 12.1 restricted `CustomAuraButton` path.

The PR remains a draft until the remaining in-client checks are complete.
